### PR TITLE
do not use # as url

### DIFF
--- a/packaging-examples/rpm-based/postscriptbarcode.spec
+++ b/packaging-examples/rpm-based/postscriptbarcode.spec
@@ -67,7 +67,7 @@ Group:          Development/Libraries
 
 License:        MIT
 URL:            http://bwipp.terryburton.co.uk
-Source0:        https://github.com/bwipp/postscriptbarcode/archive/master.tar.gz#/%{name}-%{version}.tar.gz
+Source0:        https://github.com/bwipp/postscriptbarcode/archive/master/%{name}-%{version}.tar.gz
 BuildRequires:  ghostscript
 BuildRequires:  swig
 BuildRequires:  java-devel


### PR DESCRIPTION
rpm5 treats `#` as comment, and there's "better" export url from github that just works