### PR TITLE
Allow for GS1 CC linkage in code128 encoding loop

### DIFF
--- a/src/code128.ps
+++ b/src/code128.ps
@@ -355,6 +355,11 @@ begin
         
             % Determine switches and shifts
             {  % common exit
+                i msglen 1 sub eq msg i get lka eq and msg i get lkc eq or {
+                    msg i get cset (seta) eq {enca} {cset (setb) eq {encb} {encc} ifelse} ifelse
+                    /i i 1 add def
+                    exit
+                } if
                 cset (seta) eq cset (setb) eq or nums 4 ge and 
                 msg i get fn1 ne and {
                     nums 2 mod 0 eq {


### PR DESCRIPTION
Check if last character is GS1-128 linkage flag and encode and exit.

Eg currently if in set C mode with a CC-A it encodes it as 2 switch characters (swb and swc) rather than a single swa (cf GS1 General Specifications standard Figure 5.9.8-9.).