### PR TITLE
Missing get in databarexpanded 0111XXX encodation check

### DIFF
--- a/src/databarexpanded.ps
+++ b/src/databarexpanded.ps
@@ -159,7 +159,7 @@ begin
                ais length 3 eq {
                    vals 0 get 0 1 getinterval (9) eq
                    vals 1 get cvi 99999 le and
-                   vals 2 cvi 999999 le and {
+                   vals 2 get cvi 999999 le and {
                        ai310x ais 2 get (11) eq and { (0111000) false exit } if
                        ai320x ais 2 get (11) eq and { (0111001) false exit } if
                        ai310x ais 2 get (13) eq and { (0111010) false exit } if


### PR DESCRIPTION
Eg `10 100 moveto ((01)90012345678908(3103)012233(15)991231) /databarexpanded /uk.co.terryburton.bwipp findresource exec
`fails