### PR TITLE
databar expanded stacked odd last row separator end check

### DIFF
--- a/src/databarexpanded.ps
+++ b/src/databarexpanded.ps
@@ -829,8 +829,6 @@ begin
 
             % Derive the separator pattern
             /sep [ row {1 exch sub} forall ] def
-            sep 0 [ 0 0 0 0 ] putinterval
-            sep row length 4 sub [ 0 0 0 0 ] putinterval
             /finderpos [  % Finder pattern module positions
                 19 98 row length 13 sub {} for
                 68 98 row length 13 sub {} for
@@ -838,7 +836,6 @@ begin
             finderpos {
                 dup 14 add 1 exch {
                     /i exch def
-                    i row length 4 sub eq { exit } if
                     row i get 0 eq {
                         row i 1 sub get 1 eq {
                             1
@@ -851,6 +848,8 @@ begin
                     sep exch i exch put
                 } for
             } forall
+            sep 0 [ 0 0 0 0 ] putinterval
+            sep row length 4 sub [ 0 0 0 0 ] putinterval
 
             % For even segment-pair symbols reverse alternate rows
             segments 4 mod 0 eq r 2 mod 1 eq and {

--- a/src/databarexpanded.ps
+++ b/src/databarexpanded.ps
@@ -838,6 +838,7 @@ begin
             finderpos {
                 dup 14 add 1 exch {
                     /i exch def
+                    i row length 4 sub eq { exit } if
                     row i get 0 eq {
                         row i 1 sub get 1 eq {
                             1


### PR DESCRIPTION
Check that don't set modules at end of last row separator for DataBar Expanded Stacked symbols when last row is odd (ends with finder), eg
`10 100 moveto ((255)9501101534001(3941)0035) (segments=6) /databarexpandedstacked /uk.co.terryburton.bwipp findresource exec`
does not match GS1 General Specifications 20.0 Section 2.6.2.1 Example 5 (extra module set at end of last row separator).