### PR TITLE
databar stacked omni composite missing 0 in clearing sep 1st 4 modules

### DIFF
--- a/src/databarstackedomnicomposite.ps
+++ b/src/databarstackedomnicomposite.ps
@@ -109,7 +109,7 @@ begin
         } if
     } bind def
     /sep [ bot {1 exch sub} forall ] def
-    sep 0 [ 0 0 0 ] putinterval
+    sep 0 [ 0 0 0 0 ] putinterval
     sep sep length 4 sub [ 0 0 0 0 ] putinterval
     18 sepfinder
     0 linheight rmoveto <<


### PR DESCRIPTION
Missing zero typo in array to clear 1st 4 modules of separator in DataBar Stacked Omnidirectional Composite, eg
`10 100 moveto ((01)0401234567890|(17)050101(10)ABC123) () /databarstackedomnicomposite /uk.co.terryburton.bwipp findresource exec` does not match GS1 General Specifications Figure 5.1-5. (4th module in composite separator shouldn't be set).