### PR TITLE
Allow for GS1 CC LNK in code128 numsscr

### DIFF
--- a/src/code128.ps
+++ b/src/code128.ps
@@ -261,10 +261,13 @@ begin
                 p msglen ge {exit} if
                 msg p get
                 dup setc exch known not {pop exit} if
-                fn1 eq {
+                dup fn1 eq {
+                    pop
                     % FNC1 in odd position of run like two digits
                     s 2 mod 0 eq {/s s 1 add def} {exit} ifelse
-                } if
+                } {
+                    -1 le {exit} if % LNK
+                } ifelse
                 /n n 1 add def
                 /s s 1 add def
                 /p p 1 add def


### PR DESCRIPTION
E.g. `10 100 moveto ((91)1|(21)12) () /gs1-128composite /uk.co.terryburton.bwipp findresource exec` fails