### PR TITLE
gs1-cc: rows <= 30, lower ECC near max, gpfenc buf increase; pdf417 c def

### DIFF
--- a/src/gs1-cc.ps
+++ b/src/gs1-cc.ps
@@ -425,14 +425,17 @@ begin
             m   40 le               {8 } if
             m   41 ge m  160 le and {16} if
             m  161 ge m  320 le and {32} if
-            m  321 ge               {64} if
+            m  321 ge m  833 le and {64} if  % 833 = 900 - 3 - 64, where 900 = 30 rows x 30 cols limit
+            m  834 ge               {32} if  % Reduce to meet advertised "up to 2361 digits" (allows max 2372) within 900 limit
             /eccws exch def
             /m m eccws add 3 add def
-            /c linwidth 52 sub 17 idiv def
-            m c idiv 90 gt {/c c 1 add def} if
-            /r m c div ceiling cvi def
-            /tgt c r mul eccws sub 3 sub dup 5 idiv 6 mul exch 5 mod add 8 mul def
-            used 8296 le {tgt used sub} {-1} ifelse
+            {  % Loop until rows <= 30 or columns >= 30 (GS1 General Specifications 5.9.2.3)
+                m cccolumns div ceiling cvi 30 le cccolumns 30 ge or {exit} if
+                /cccolumns cccolumns 1 add def
+            } loop
+            /r m cccolumns div ceiling cvi def
+            /tgt cccolumns r mul eccws sub 3 sub dup 5 idiv 6 mul exch 5 mod add 8 mul def
+            used 8304 le {tgt used sub} {-1} ifelse
         } ifelse
         dup -1 eq {  % Upgrade CC-A to CC-B or CC-B to CC-C to fit
             pop
@@ -486,7 +489,7 @@ begin
     } for
 
     % Encode the general purpose field
-    /gpfenc 8296 array def
+    /gpfenc 8304 array def  % 8304 = (865 / 5) * 6 * 8, where 865 = 900 - 3 - 32
     /i 0 def /j 0 def
     {  % loop
         i gpf length eq {exit} if
@@ -680,6 +683,7 @@ begin
         options (dontdraw) true put
         options (ccc) true put
         options (columns) cccolumns put
+        options (eclevel) eccws ln 2 ln div cvi 1 sub put
         /args barcode options //pdf417 exec def
     } if
 

--- a/src/pdf417.ps
+++ b/src/pdf417.ps
@@ -541,7 +541,7 @@ begin
 
     % To determine size of matrix, number of columns if given by user...
     columns 0 eq {/columns m k add 3 div sqrt round cvi def} if
-    columns 1 ge columns 30 le and {/c columns def} if
+    /c columns 1 ge {columns} {1} ifelse def
 
     % ... and rows is greater of those required and that given by user within limits
     /r m k add 1 add columns div ceiling cvi def  % Required


### PR DESCRIPTION
You may or may not be interested in this, which implements the GS1 General Specifications Section 5.9.2.3 guideline of rows <= 30 for CC-C.
- increases the `gpfenc` buffer by 8 to allow for the max 30x30 size
- loops in `rembits` until rows <= 30 or columns >= 30
- uses `cccolumns` so that it gets passed to pdf417 (along with `eclevel`)
- makes sure that `c` is defined in pdf417 if `columns` is > 30

Given the 30x30 limit, it means that the ECC has to be reduced from the recommended 64 to 32 for codeword counts near the max. This isn't mentioned or dealt with in the GS1 spec so it's debatable whether the conclusion is valid...