### PR TITLE
code2of5: set sbs length using stop char length

### DIFF
--- a/src/code2of5.ps
+++ b/src/code2of5.ps
@@ -137,7 +137,7 @@ begin
     % Create a string of the available characters
     /barchars (0123456789) def
 
-    /sbs barlen includecheck {1 add} if cs mul ss add ss add string def
+    /sbs barlen includecheck {1 add} if cs mul ss add encs 11 get length add string def
     /txt barlen includecheck {1 add} if array def
 
     % Put the start character


### PR DESCRIPTION
Sets `sbs` length correctly for `code2of5` by using stop char length rather than start. Non-functional as ignored by `renlinear` but stops `sbs` having -48 as last entry.