### PR TITLE
micropdf417: don't bother setting state before auto datcws seq encode

### DIFF
--- a/src/micropdf417.ps
+++ b/src/micropdf417.ps
@@ -509,7 +509,7 @@ begin
         } bind def
 
         % Encode the sequence
-        /state T def /submode A def
+        % No need to set state as seq will always begin with a latch, unlike for pdf417
         /datcws seqlen array def
         /i 0 def /j 0 def {
             i seq length ge {exit} if


### PR DESCRIPTION
This is purely for tidiness and completely non-functional but when integrating Zint testing for MICROPDF417 noticed that at the beginning of the datcws seq encode block in auto the state is set to Alpha Compaction when the default for micropdf417 is Byte. Obviously could just change this to Byte, however I don't think it matters here, unlike in the pdf417 case, as the seq array will always begin with a scalar latch, so the suggestion is to not set the state here at all.