### PR TITLE
code32: use temp string for cvrs

### DIFF
--- a/src/code32.ps
+++ b/src/code32.ps
@@ -103,7 +103,7 @@ begin
     /text exch def
 
     % convert number from base10 to base32
-    /val text cvi 32 barcode cvrs def
+    /val text cvi 32 6 string cvrs def
     /barcode 6 string def
     0 1 5 {barcode exch 48 put} for
     barcode 6 val length sub val putinterval


### PR DESCRIPTION
E.g. `10 100 moveto (34567890) readonly () /code32 /uk.co.terryburton.bwipp findresource exec` fails