### PR TITLE
databarlimited and composite 5 right guard spaces

### DIFF
--- a/src/databarlimited.ps
+++ b/src/databarlimited.ps
@@ -291,7 +291,7 @@ begin
     } for
 
     /sbs [
-        1 d1w {} forall checkwidths {} forall d2w {} forall 1 1
+        1 d1w {} forall checkwidths {} forall d2w {} forall 1 1 5
     ] def
 
     % Return the arguments

--- a/src/databarlimitedcomposite.ps
+++ b/src/databarlimitedcomposite.ps
@@ -92,7 +92,7 @@ begin
     1 linsbs {1 index 0 eq {{1}} {{0}} ifelse repeat} forall
     counttomark 1 sub array astore /sep exch def pop pop
     sep 0 [0 0 0] putinterval
-    sep sep length 4 sub [0 0 0 0] putinterval
+    sep sep length 9 sub [0 0 0 0 0 0 0 0 0] putinterval % 4 + 5 right guard spaces
     0 linheight rmoveto <<
         /ren //renmatrix
         /pixs sep


### PR DESCRIPTION
Adds 5 right guard spaces to databarlimited as specced by ISO/IEC 24724:2011 Section 6.2 (e) (second edition addition it appears), and adjusts the databarlimitedcomposite separator accordingly. For the latter

`20 100 moveto ((01)1311234567890|(17)010615(10)A123456) () /databarlimitedcomposite /uk.co.terryburton.bwipp findresource exec`

still reproduces Figure 5.9.2-1. in GS1 General Specifications v20.0 (Figure 1 in ISO/IEC 24723:2010).