### PR TITLE
pharmacode2: set bhs/bbs lengths exactly

### DIFF
--- a/src/pharmacode2.ps
+++ b/src/pharmacode2.ps
@@ -87,8 +87,6 @@ begin
     } for
 
     /encstr 16 string def
-    /bhs 16 array def
-    /bbs 16 array def
     /sbs 32 array def
     /bar 1 25.4 div height mul def     % bar height (mm)
     /spc 1 25.4 div 72 mul def         % bar width & spacing (1mm)
@@ -106,6 +104,8 @@ begin
     /encstr encstr i 1 add 15 i sub getinterval def
 
     % Generate the bar pattern
+    /bhs encstr length array def
+    /bbs encstr length array def
     0 1 encstr length 1 sub {
         /i exch def
         encstr i get dup


### PR DESCRIPTION
For instance `/ret (8) (dontdraw) /pharmacode2 /uk.co.terryburton.bwipp findresource exec def ret /bhs get ==` has nulls at end.