### PR TITLE
databarexpandedstackedcomposite: missing 0 in clearing sep 1st 4 modules

### DIFF
--- a/src/databarexpandedstackedcomposite.ps
+++ b/src/databarexpandedstackedcomposite.ps
@@ -104,7 +104,7 @@ begin
         } for
     } bind def
     /sep [ bot {1 exch sub} forall ] def
-    sep 0 [ 0 0 0 ] putinterval
+    sep 0 [ 0 0 0 0 ] putinterval
     sep sep length 4 sub [ 0 0 0 0 ] putinterval
     [  % Finder pattern module positions
         19 98 bot length 13 sub {} for


### PR DESCRIPTION
Missing zero typo in array to clear 1st 4 modules of separator in DataBar Expanded Stacked Composite, eg for
`10 200 moveto ((20)12|(21)1234) () /databarexpandedstackedcomposite /uk.co.terryburton.bwipp findresource exec` the 4th module (looks like 3rd because barcode begins with a space) in composite separator shouldn't be set (cf https://github.com/bwipp/postscriptbarcode/pull/118).