### PR TITLE
pdf417/micropdf417 ECI: adjust seqlen, missing astore, remove swapping

### DIFF
--- a/src/micropdf417.ps
+++ b/src/micropdf417.ps
@@ -268,19 +268,19 @@ begin
         /seq [] def /seqlen 0 def /state B def /p 0 def {  % loop
             p msglen eq {exit} if
             iseci p get {
+                /eci msg p get def
                 /seq [
                     seq aload pop
-                    [ msg p get ]
+                    [ eci ]
                 ] def
                 /p p 1 add def
-                /seqlen seqlen 1 add def
+                /seqlen seqlen eci -1810900 le {2} {eci -1000900 le {3} {2} ifelse} ifelse add def
             } {
             /n numdigits p get def
             n 13 ge {
                 /seq [
                     seq aload pop
                     nl
-                    p 0 gt {iseci p 1 sub get {exch} if} if
                     [ msg p n getinterval aload pop ]
                 ] def
                 /state N def
@@ -293,7 +293,6 @@ begin
                     seq aload pop
                     state T ne {
                         tl
-                        p 0 gt {iseci p 1 sub get {exch} if} if
                     } if
                     [ msg p t getinterval aload pop ]
                 ] def
@@ -306,7 +305,6 @@ begin
                 /seq [
                     seq aload pop
                     bs
-                    p 0 gt {iseci p 1 sub get {exch} if} if
                     [ msg p get ]
                 ] def
                 /p p b add def
@@ -315,7 +313,6 @@ begin
                 /seq [
                     seq aload pop
                     b 6 mod 0 ne {bl} {bl6} ifelse
-                    p 0 gt {iseci p 1 sub get {exch} if} if
                     [ msg p b getinterval aload pop ]
                 ] def
                 /state B def
@@ -513,7 +510,7 @@ begin
             } { dup 810899 le {  % ECI 000900 - 810899
                 926 exch dup 900 idiv 1 sub exch 900 mod 3 array astore
             } { dup 811799 le {  % ECI 810900 - 811799
-                925 exch 810900 sub 2 array
+                925 exch 810900 sub 2 array astore
             } {
                 /bwipp.pdf417badECI (PDF417 supports ECIs 000000 to 811799) //raiseerror exec
             } ifelse } ifelse } ifelse

--- a/src/pdf417.ps
+++ b/src/pdf417.ps
@@ -262,19 +262,19 @@ begin
         /seq [] def /seqlen 0 def /state T def /p 0 def {  % loop
             p msglen eq {exit} if
             iseci p get {
+                /eci msg p get def
                 /seq [
                     seq aload pop
-                    [ msg p get ]
+                    [ eci ]
                 ] def
                 /p p 1 add def
-                /seqlen seqlen 1 add def
+                /seqlen seqlen eci -1810900 le {2} {eci -1000900 le {3} {2} ifelse} ifelse add def
             } {
             /n numdigits p get def
             n 13 ge {
                 /seq [
                     seq aload pop
                     nl
-                    p 0 gt {iseci p 1 sub get {exch} if} if
                     [ msg p n getinterval aload pop ]
                 ] def
                 /state N def
@@ -287,7 +287,6 @@ begin
                     seq aload pop
                     state T ne {
                         tl
-                        p 0 gt {iseci p 1 sub get {exch} if} if
                     } if
                     [ msg p t getinterval aload pop ]
                 ] def
@@ -300,7 +299,6 @@ begin
                 /seq [
                     seq aload pop
                     bs
-                    p 0 gt {iseci p 1 sub get {exch} if} if
                     [ msg p get ]
                 ] def
                 /p p b add def
@@ -309,7 +307,6 @@ begin
                 /seq [
                     seq aload pop
                     b 6 mod 0 ne {bl} {bl6} ifelse
-                    p 0 gt {iseci p 1 sub get {exch} if} if
                     [ msg p b getinterval aload pop ]
                 ] def
                 /state B def
@@ -506,7 +503,7 @@ begin
             } { dup 810899 le {  % ECI 000900 - 810899
                 926 exch dup 900 idiv 1 sub exch 900 mod 3 array astore
             } { dup 811799 le {  % ECI 810900 - 811799
-                925 exch 810900 sub 2 array
+                925 exch 810900 sub 2 array astore
             } {
                 /bwipp.pdf417badECI (PDF417 supports ECIs 000000 to 811799) //raiseerror exec
             } ifelse } ifelse } ifelse


### PR DESCRIPTION
For pdf417 and micropdf417 ECI handling:

- Allows for extra codewords in `seqlen`
- Missing `astore` in the 810900 - 811799 branch of `ence`
- Removes swapping of ECI from before to after mode switches

The last is based on interpreting Sections 5.5.3.2 and 5.5.3.4 of ISO/IEC 15438:2015 as meaning that within the mode the mentioned placements are the only ones valid, but that it's fine for an ECI to occur before (i.e. outside) the mode.

The Section 5.5.3.3 Byte Shift case without the change causes eg. `10 200 moveto (^ECI000009^226) (parse parsefnc) /pdf417 /uk.co.terryburton.bwipp findresource exec` to fail, which could be dealt with in the "Encode the sequence" loop instead, but it seems much more natural to solve it by not swapping...