### PR TITLE
gs1-format-spec: 253/255 2nd optional; 4309 rm; 719 -> 714; 8005 fixed

### DIFF
--- a/contrib/development/gs1-format-spec.txt
+++ b/contrib/development/gs1-format-spec.txt
@@ -25,9 +25,9 @@
 243       X..20
 250       X..30
 251       X..30
-253       N13,csum,key X..17
+253       N13,csum,key X0..17
 254       X..20
-255       N13,csum,key N..12
+255       N13,csum,key N0..12
 30        N..8
 3100-3105 N6
 3110-3115 N6
@@ -111,7 +111,6 @@
 4306      X..70,pcenc
 4307      X2
 4308      X..30,pcenc
-4309      X..35,pcenc
 4310      X..35,pcenc
 4311      X..70,pcenc
 4312      X..70,pcenc
@@ -145,14 +144,14 @@
 7023      X..30,key
 7030-7039 N3,isocc X..27
 7040      N1 X1 X1 X1,importeridx
-710-719   X..20
+710-714   X..20
 7230-7239 X2 X..28
 7240      X..20
 8001      N4,nonzero N5,nonzero N3,nonzero N1,winding N1
 8002      X..20
 8003      N1,zero N13,csum,key X0..16
 8004      X..30,key
-8005      N..6
+8005      N6
 8006      N14,csum N4,pieceoftotal
 8007      X..34,iban
 8008      N6,yymmdd N..6,hhoptmmss


### PR DESCRIPTION
Remove extraneous 4309, plus some adjustments spotted when running against the current Zint tests.