### PR TITLE
gs1-format-spec: 4308 no pcenc

### DIFF
--- a/contrib/development/gs1-format-spec.txt
+++ b/contrib/development/gs1-format-spec.txt
@@ -110,7 +110,7 @@
 4305      X..70,pcenc
 4306      X..70,pcenc
 4307      X2,iso3166alpha2
-4308      X..30,pcenc
+4308      X..30
 4310      X..35,pcenc
 4311      X..35,pcenc
 4312      X..70,pcenc

--- a/src/gs1lint.ps
+++ b/src/gs1lint.ps
@@ -1270,7 +1270,7 @@ begin
         pop
 
         [
-        << /cset /X  /min  1  /max 30  /check [ /lintpcenc ] >>
+        << /cset /X  /min  1  /max 30  /check [] >>
         ]
         (4308) exch dup
         pop

--- a/tests/ps_tests/gs1lint.ps
+++ b/tests/ps_tests/gs1lint.ps
@@ -248,6 +248,10 @@
 ((4320)ABCDEFGHIJKLMNOPQRSTUVWXYZ%00+12345) good_tmpl
 ((4320)ABCDEFGHIJKLMNOPQRSTUVWXYZ%00+123456) /bwipp.GS1valueTooLong er_tmpl
 
+% X..30 (no pcenc)
+((4308)ABCDEFGHIJKLMNOPQRSTUVWXYZ%+12) good_tmpl
+((4308)ABCDEFGHIJKLMNOPQRSTUVWXYZ%+123) /bwipp.GS1valueTooLong er_tmpl
+
 % N1,yesno
 ((4321)0) good_tmpl
 ((4321)1) good_tmpl


### PR DESCRIPTION
Missed this, (4308) does not use percent encoding.