### PR TITLE
codeone: lookup Q5; encCTX ctxvals missing, Steps E1c, E2; numD EOD checks

### DIFF
--- a/src/codeone.ps
+++ b/src/codeone.ps
@@ -397,15 +397,15 @@ begin
                     /tc tc isT {2 3 div add} {isEA { 8 3 div add } { 4 3 div add } ifelse} ifelse def
                     /xc xc isX {2 3 div add} {isEA {13 3 div add } {10 3 div add } ifelse} ifelse def
                     /bc bc isFN {3 add} {1 add} ifelse def
-                    k 3 ge {
+                    k 3 ge {  % Checking after at least 4 characters (cf. Data Matrix), not 3 as in spec Step Q
                         true [ac cc tc xc   ] {bc 1 add exch ceiling le and} forall {B exit} if
                         true [   cc tc xc bc] {ac 1 add exch ceiling le and} forall {A exit} if
-                        true [ac cc    xc bc] {tc 1 add exch ceiling le and} forall {T exit} if
-                        true [ac    tc      ] {cc 1 add exch ceiling le and} forall {
+                        true [ac cc    xc bc] {tc ceiling 1 add exch ceiling le and} forall {T exit} if
+                        true [ac    tc      ] {cc ceiling 1 add exch ceiling le and} forall {
                             cc ceiling xc ceiling lt {C exit} if
                             cc xc eq {i k add 1 add XtermFirst {X exit} {C exit} ifelse} if
                         } if
-                        true [ac cc tc    bc] {xc 1 add exch lt and} forall {X exit} if
+                        true [ac cc tc    bc] {xc ceiling 1 add exch ceiling le and} forall {X exit} if
                     } if
                     /k k 1 add def
                 } loop
@@ -485,24 +485,43 @@ begin
             % Lookup the values for each character
             {
                 i msglen eq {exit} if
-                encvals mode get msg i get known not {exit} if
                 p 3 mod 0 eq {
                     numD i get 12 ge {
-                        [unlcw] addtocws
-                        /mode A def
-                        exit
-                    } if
-                    numD i get dup 8 ge exch i add msglen eq and {
-                        [unlcw] addtocws
-                        /mode A def
-                        exit
-                    } if
-                    lookup mode ne {
                         ctxvals 0 p getinterval CTXvalstocws addtocws
                         [unlcw] addtocws
                         /mode A def
                         exit
                     } if
+                    numD i get dup 8 ge exch i add msglen eq and {
+                        ctxvals 0 p getinterval CTXvalstocws addtocws
+                        [unlcw] addtocws
+                        /mode A def
+                        exit
+                    } if
+                    mode X eq {  % Steps E1c, E2
+                        Xvals msg i get known not {
+                            ctxvals 0 p getinterval CTXvalstocws addtocws
+                            % Unlatch to ASCII unless one codeword left and single ASCII to encode
+                            numremcws j get 1 ne msg i get 127 gt or {
+                                [unlcw] addtocws
+                            } if
+                            /mode A def
+                            exit
+                        } if
+                        i 1 add msglen lt {
+                            Xvals msg i 1 add get known not {exit} if
+                            i 2 add msglen lt {
+                                Xvals msg i 2 add get known not {exit} if
+                            } if
+                        } if
+                    } {
+                        lookup mode ne {
+                            ctxvals 0 p getinterval CTXvalstocws addtocws
+                            [unlcw] addtocws
+                            /mode A def
+                            exit
+                        } if
+                    } ifelse
                     msglen i sub 3 le {  % Check end of data conditions
                         /remcws numremcws j p 3 idiv 2 mul add get def
                         /remvals [
@@ -596,11 +615,17 @@ begin
                     /remcws numremcws j Dbits length 8 idiv add get def
 
                     % Final codeword with no data
-                    numremcws j Dbits length 8 idiv add 1 sub get 1 sub 0 eq
-                    i msglen eq and {exit} if
+                    numremcws j Dbits length 8 idiv add 1 sub get 1 sub 0 eq Drem 0 eq and  % No remaining codewords and no bits
+                    remcws 1 eq Drem 0 ne and or  % Or 1 remaining codeword and some bits
+                    i msglen eq and {
+                        Drem 4 eq Drem 6 eq or { /Dbits [ Dbits aload pop 1 1 1 1 ] def } if
+                        Drem 2 eq Drem 6 eq or { /Dbits [ Dbits aload pop 0 1 ] def } if
+                        exit
+                    } if
 
-                    % Final digit into final codeword as ASCII
+                    % Final digit or double-digit into final codeword as ASCII
                     i msglen 1 sub eq numD i get 1 eq and
+                    i msglen 2 sub eq numD i get 2 eq and or
                     remcws 1 eq and Drem 0 eq and {exit} if
 
                     % Latch to ASCII unless 4 or 6 bits remain in final codeword
@@ -709,6 +734,8 @@ begin
     } {
         /cws [ dcws cws length sub {0} repeat cws aload pop ] def
     } ifelse
+
+    options /debugcws known { /bwipp.debugcws cws //raiseerror exec } if
 
     % De-interleave the codewords into blocks
     /cwbs rsbl array def  % Array of data codeword blocks

--- a/tests/ps_tests/codeone.ps
+++ b/tests/ps_tests/codeone.ps
@@ -1,0 +1,174 @@
+%!PS
+
+% AIM USS Code One Revision March 3, 2000
+
+% vim: set ts=4 sw=4 et :
+
+/codeone dup /uk.co.terryburton.bwipp findresource cvx def
+
+
+% EDI
+
+{
+    (^013*>^013*) (debugcws parse) codeone  % 1 EDI triplet + doublet, ASCII mode
+} [14 43 63 14 43 129 129 129 129 129] debugIsEqual
+
+{
+    (^013*>^013*>) (debugcws parse) codeone  % 2 EDI triplets, EDI mode
+} [238 0 43 0 43 255 129 129 129 129] debugIsEqual
+
+{
+    (^013*>^013*>a) (debugcws parse) codeone  % 2 EDI triplets + 1 non-EDI (Steps E1c, E2 and Step Q5)
+} [238 0 43 0 43 255 98 129 129 129] debugIsEqual
+
+{
+    (^013*>^013*>^013a) (debugcws parse) codeone  % 2 EDI triplets + singlet + 1 non-EDI (Steps E1c, E2)
+} [238 0 43 0 43 255 14 98 129 129] debugIsEqual
+
+{
+    (^013*>^013*>^013*a) (debugcws parse) codeone  % 2 EDI triplets + doublet + 1 non-EDI (Steps E1c, E2)
+} [238 0 43 0 43 255 14 43 98 129] debugIsEqual
+
+
+% DECIMAL
+
+{
+    (123456789012345678901) (debugcws) codeone  % 1 remaining codeword and some bits
+} [241 241 201 197 128 213 106 167 225 189] debugIsEqual
+
+{
+    (123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890) (debugcws version=T-48) codeone  % No remaining codewords and no bits
+} [241 241 201 197 128 213 106 167 225 142 184 227 123 31 28 156 88 13 86 170 126 24 235 142 55 177 241 201 197 128 213 106 167 225 142 184 227 123] debugIsEqual
+
+{
+    (1234567890123456789012345678901234567890123) (debugcws) codeone  % Final digit into final codeword as ASCII
+} [241 241 201 197 128 213 106 167 225 142 184 227 123 31 28 156 88 13 52] debugIsEqual
+
+{
+    (12345678901234567890123456789012345678901234) (debugcws) codeone  % Last 2 digits into final codeword as ASCII double-digit
+} [241 241 201 197 128 213 106 167 225 142 184 227 123 31 28 156 88 13 164] debugIsEqual
+
+
+% Figures
+
+{
+    (1234567890123456789012) (debugcws) codeone  % Figure 1, Version A, same
+} [241 241 201 197 128 213 106 167 225 141] debugIsEqual
+
+{
+    (???????????????????????????????????????????????????????????????????????????????????????????) (debugcws) codeone  % Figure 7, Version D, same
+} [64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64 64] debugIsEqual
+
+{
+    (1234567890) (debugcws version=S-20) codeone  % Figure 9 (left) (note S-20 not S-10 as stated), same
+} [0 1 4 25 12 0 22 19] debugIsEqual
+
+{
+    (12345678901234567890) (debugcws version=T-16) codeone  % Figure 9 (right), not the same, BWIPP uses DECIMAL, figure ASCII double-digits, same no. of codewords
+} [241 241 201 197 128 213 106 167 253 220] debugIsEqual
+
+{
+    (^FNC101003123412340141595091530ABC123456) (debugcws version=B parsefnc) codeone  % Figure B1 (note uses non-compliant (30) instead of (10) as BATCH/LOT NO), same
+} [236 2 194 3 172 124 100 154 14 223 148 253 160 66 67 68 142 164 186] debugIsEqual
+
+
+% Table 2 data capacities of each Code One Version
+
+/dcap_tmpl {
+    /ver exch def /str exch def /cnt exch def /opt (dontdraw version=) def
+    % Substituting stack strings into proc so show up in error stack
+    opt length ver length add string dup dup 0 opt putinterval opt length ver putinterval  % Concatenate opt and ver for options
+    cnt string 0 1 cnt 1 sub { exch dup 3 -1 roll str putinterval } for  % Expand string for data
+    % 0 1 are placeholders for data and options
+    { 0 1 codeone /pixs known } dup 3 -1 roll 0 exch put  % Substitute data for placeholder 0
+    dup 3 -1 roll 1 exch put  % Substitute options for placeholder 1
+} def
+
+6 (1) (S-10) dcap_tmpl true isEqual
+7 (1) (S-10) dcap_tmpl /rangecheck isError
+
+12 (1) (S-20) dcap_tmpl true isEqual
+13 (1) (S-20) dcap_tmpl /rangecheck isError
+
+18 (1) (S-30) dcap_tmpl true isEqual
+19 (1) (S-30) dcap_tmpl /rangecheck isError
+
+13 (A) (T-16) dcap_tmpl true isEqual
+14 (A) (T-16) dcap_tmpl /rangecheck isError
+22 (1) (T-16) dcap_tmpl true isEqual
+23 (1) (T-16) dcap_tmpl /rangecheck isError
+10 <01> (T-16) dcap_tmpl true isEqual
+11 <01> (T-16) dcap_tmpl /rangecheck isError
+
+34 (A) (T-32) dcap_tmpl true isEqual
+35 (A) (T-32) dcap_tmpl /rangecheck isError
+56 (1) (T-32) dcap_tmpl true isEqual
+57 (1) (T-32) dcap_tmpl /rangecheck isError
+24 <01> (T-32) dcap_tmpl true isEqual
+25 <01> (T-32) dcap_tmpl /rangecheck isError
+
+55 (A) (T-48) dcap_tmpl true isEqual
+56 (A) (T-48) dcap_tmpl /rangecheck isError
+90 (1) (T-48) dcap_tmpl true isEqual
+91 (1) (T-48) dcap_tmpl /rangecheck isError
+89 (1) (T-48) dcap_tmpl /rangecheck isError  % Quirk of DECIMAL end-of-data encoding when capacity multiple of 3
+38 <01> (T-48) dcap_tmpl true isEqual
+39 <01> (T-48) dcap_tmpl /rangecheck isError
+
+13 (A) (A) dcap_tmpl true isEqual
+14 (A) (A) dcap_tmpl /rangecheck isError
+22 (1) (A) dcap_tmpl true isEqual
+23 (1) (A) dcap_tmpl /rangecheck isError
+10 <01> (A) dcap_tmpl true isEqual
+11 <01> (A) dcap_tmpl /rangecheck isError
+
+27 (A) (B) dcap_tmpl true isEqual
+28 (A) (B) dcap_tmpl /rangecheck isError
+44 (1) (B) dcap_tmpl true isEqual
+45 (1) (B) dcap_tmpl /rangecheck isError
+19 <01> (B) dcap_tmpl true isEqual
+20 <01> (B) dcap_tmpl /rangecheck isError
+
+64 (A) (C) dcap_tmpl true isEqual
+65 (A) (C) dcap_tmpl /rangecheck isError
+104 (1) (C) dcap_tmpl true isEqual
+105 (1) (C) dcap_tmpl /rangecheck isError
+44 <01> (C) dcap_tmpl true isEqual
+45 <01> (C) dcap_tmpl /rangecheck isError
+
+135 (A) (D) dcap_tmpl true isEqual
+136 (A) (D) dcap_tmpl /rangecheck isError
+217 (1) (D) dcap_tmpl true isEqual
+218 (1) (D) dcap_tmpl /rangecheck isError
+91 <01> (D) dcap_tmpl true isEqual
+92 <01> (D) dcap_tmpl /rangecheck isError
+
+271 (A) (E) dcap_tmpl true isEqual
+272 (A) (E) dcap_tmpl /rangecheck isError
+435 (1) (E) dcap_tmpl true isEqual
+436 (1) (E) dcap_tmpl /rangecheck isError
+434 (1) (E) dcap_tmpl /rangecheck isError  % Quirk of DECIMAL end-of-data encoding when capacity multiple of 3
+182 <01> (E) dcap_tmpl true isEqual
+183 <01> (E) dcap_tmpl /rangecheck isError
+
+553 (A) (F) dcap_tmpl true isEqual
+554 (A) (F) dcap_tmpl /rangecheck isError
+886 (1) (F) dcap_tmpl true isEqual
+887 (1) (F) dcap_tmpl /rangecheck isError
+370 <01> (F) dcap_tmpl true isEqual
+371 <01> (F) dcap_tmpl /rangecheck isError
+
+1096 (A) (G) dcap_tmpl true isEqual
+1097 (A) (G) dcap_tmpl /rangecheck isError
+1755 (1) (G) dcap_tmpl true isEqual
+1756 (1) (G) dcap_tmpl /rangecheck isError
+1754 (1) (G) dcap_tmpl /rangecheck isError  % Quirk of DECIMAL end-of-data encoding when capacity multiple of 3
+732 <01> (G) dcap_tmpl true isEqual
+733 <01> (G) dcap_tmpl /rangecheck isError
+
+2218 (A) (H) dcap_tmpl true isEqual
+2219 (A) (H) dcap_tmpl /rangecheck isError
+3550 (1) (H) dcap_tmpl true isEqual
+3551 (1) (H) dcap_tmpl /rangecheck isError
+1480 <01> (H) dcap_tmpl true isEqual
+1481 <01> (H) dcap_tmpl /rangecheck isError

--- a/tests/ps_tests/test.ps
+++ b/tests/ps_tests/test.ps
@@ -58,6 +58,7 @@
 [
     (../../../tests/ps_tests/parseinput.ps)
     (../../../tests/ps_tests/gs1lint.ps)
+    (../../../tests/ps_tests/codeone.ps)
     (../../../tests/ps_tests/databarexpanded.ps)
     (../../../tests/ps_tests/databarexpandedstacked.ps)
     (../../../tests/ps_tests/gs1northamericancoupon.ps)


### PR DESCRIPTION
Some Code One changes:

- lookup: adjusts count check for EDI (Step Q5) to be same as spec - was exiting EDI mode too early in a number of cases; also TEXT and C40 rounding added
- encCTX: adds missing ctxvals buffer transfers on numeric check exits
- encCTX: adds Steps E1c and E2 when in EDI mode
- encD: allows for 1 remaining codeword and some remaining bits on "Final codeword with no data" check; also adds check that no remaining bits if no codewords left
- encD: allows for being able to encode 2 digits in an ASCII double-digit on "Final codeword as ASCII" check (figures given in Table 2 data capacity are now met)

New test file "tests/ps_tests/codeone.ps".