### PR TITLE
Allow creating standalone file with more than one encoder

### DIFF
--- a/build/make_standalone
+++ b/build/make_standalone
@@ -4,11 +4,24 @@ use strict;
 use File::Temp;
 use File::Basename;
 
-my $infile=$ARGV[0];
-my $outfile=$ARGV[1];
+if ($#ARGV < 1) {
+    die <<EOF
+Usage: $0 <infile> <outfile> [<encoder>...]
 
-my $encoder=basename($outfile);
-$encoder=~s/\.ps$//;
+If encoders are not specified explicitly, the single encoder name is deduced
+from the name of the output file.
+EOF
+}
+
+my $infile=shift;
+my $outfile=shift;
+
+my @encoders = @ARGV;
+if (!@encoders) {
+    my $encoder=basename($outfile);
+    $encoder=~s/\.ps$//;
+    push @encoders, $encoder;
+}
 
 open(VER,'CHANGES') || die 'Unable to open CHANGES';
 my $version=<VER>;
@@ -26,30 +39,32 @@ close(PS);
 
 open(PS,">$outfile") || die "Failed to write $outfile";
 print PS $head;
-($_,$_,my $meta,$_)=$template=~/
-    ^%\ --BEGIN\ (ENCODER|RENDERER|RESOURCE)\ ($encoder)--$
-    (.*?)
-    (^[^%].*?)
-    ^%\ --END\ \1\ \2--$
-/msgx or die 'Encoder unknown';
-(my $reqs)=$meta=~/^% --REQUIRES (.*)--$/mg;
-$reqs='' unless defined $reqs;
-my %reqs=($encoder=>1);
-$reqs{$_}=1 foreach split ' ', $reqs;
+for my $encoder (@encoders) {
+    ($_,$_,my $meta,$_)=$template=~/
+        ^%\ --BEGIN\ (ENCODER|RENDERER|RESOURCE)\ ($encoder)--$
+        (.*?)
+        (^[^%].*?)
+        ^%\ --END\ \1\ \2--$
+    /msgx or die 'Encoder unknown';
+    (my $reqs)=$meta=~/^% --REQUIRES (.*)--$/mg;
+    $reqs='' unless defined $reqs;
+    my %reqs=($encoder=>1);
+    $reqs{$_}=1 foreach split ' ', $reqs;
 
-while ($template=~/
-    ^%\ --BEGIN\ (ENCODER|RENDERER|RESOURCE)\ ([\w-]+?)--$
-    (.*?)
-    (^%%.*?)
-    (^[^%].*?)
-    ^%\ --END\ \1\ \2--$
-/msgx) {
-  my $resource=$2;
-  my $meta=$3;
-  my $dsc=$4;
-  my $body=$5;
-  next unless $reqs{$resource};
-  print PS "$dsc$body\n";
+    while ($template=~/
+        ^%\ --BEGIN\ (ENCODER|RENDERER|RESOURCE)\ ([\w-]+?)--$
+        (.*?)
+        (^%%.*?)
+        (^[^%].*?)
+        ^%\ --END\ \1\ \2--$
+    /msgx) {
+      my $resource=$2;
+      my $meta=$3;
+      my $dsc=$4;
+      my $body=$5;
+      next unless $reqs{$resource};
+      print PS "$dsc$body\n";
+    }
 }
 
 close(PS);

--- a/build/make_standalone
+++ b/build/make_standalone
@@ -4,9 +4,6 @@ use strict;
 use File::Temp;
 use File::Basename;
 
-my $abspath=`pwd`;
-chomp $abspath;
-
 my $infile=$ARGV[0];
 my $outfile=$ARGV[1];
 


### PR DESCRIPTION
AFAICS, currently it's only possible to create a standalone file with a single encoder (and all its dependencies), while some applications may need to use a couple (in my case, at least 2 but maybe up to 4) different symbologies, so I've extended the script to allow creating a standalone file with just the encoders needed and am submitting it here in case it might be useful for others.
