### PR TITLE
Avoid duplication in make_standalone with multiple encoders

### DIFF
--- a/build/make_standalone
+++ b/build/make_standalone
@@ -39,6 +39,8 @@ close(PS);
 
 open(PS,">$outfile") || die "Failed to write $outfile";
 print PS $head;
+
+my %seen;
 for my $encoder (@encoders) {
     ($_,$_,my $meta,$_)=$template=~/
         ^%\ --BEGIN\ (ENCODER|RENDERER|RESOURCE)\ ($encoder)--$
@@ -63,6 +65,7 @@ for my $encoder (@encoders) {
       my $dsc=$4;
       my $body=$5;
       next unless $reqs{$resource};
+      next if $seen{$resource}++;
       print PS "$dsc$body\n";
     }
 }


### PR DESCRIPTION
This corrects a problem in the recent 6d673f6 (Extend make_standalone
script to allow for more than 1 encoder, 2021-02-12) which could (and
did) result in having duplicated dependencies in the generated files.
While this didn't seem to result in any problems, it is still at best
completely unnecessary.

Keep track of the dependencies we had already seen to prevent this from
happening.

---

Sorry, my [previous PR](https://github.com/bwipp/postscriptbarcode/pull/144) wasn't quite correct, so here is another one amending it slightly to avoid having duplicated sections in the output.