### PR TITLE
gs1-format-spec: add "# Data title" comments

### DIFF
--- a/contrib/development/gs1-format-spec.txt
+++ b/contrib/development/gs1-format-spec.txt
@@ -4,168 +4,180 @@
 # X0..20 -> 0 <= |X| <= 20   # Field is optional
 #
 
-00        N18*,csum,key
-01        N14*,csum,key
-02        N14*,csum,key
-10        X..20
-11        N6*,yymmd0
-12        N6*,yymmd0
-13        N6*,yymmd0
-15        N6*,yymmd0
-16        N6*,yymmd0
-17        N6*,yymmd0
-20        N2*
-21        X..20
-22        X..20
-235       X..28
-240       X..30
-241       X..30
-242       N..6
-243       X..20
-250       X..30
-251       X..30
-253       N13,csum,key X0..17
-254       X..20
-255       N13,csum,key N0..12
-30        N..8
-3100-3105 N6*
-3110-3115 N6*
-3120-3125 N6*
-3130-3135 N6*
-3140-3145 N6*
-3150-3155 N6*
-3160-3165 N6*
-3200-3205 N6*
-3210-3215 N6*
-3220-3225 N6*
-3230-3235 N6*
-3240-3245 N6*
-3250-3255 N6*
-3260-3265 N6*
-3270-3275 N6*
-3280-3285 N6*
-3290-3295 N6*
-3300-3305 N6*
-3310-3315 N6*
-3320-3325 N6*
-3330-3335 N6*
-3340-3345 N6*
-3350-3355 N6*
-3360-3365 N6*
-3370-3375 N6*
-3400-3405 N6*
-3410-3415 N6*
-3420-3425 N6*
-3430-3435 N6*
-3440-3445 N6*
-3450-3455 N6*
-3460-3465 N6*
-3470-3475 N6*
-3480-3485 N6*
-3490-3495 N6*
-3500-3505 N6*
-3510-3515 N6*
-3520-3525 N6*
-3530-3535 N6*
-3540-3545 N6*
-3550-3555 N6*
-3560-3565 N6*
-3570-3575 N6*
-3600-3605 N6*
-3610-3615 N6*
-3620-3625 N6*
-3630-3635 N6*
-3640-3645 N6*
-3650-3655 N6*
-3660-3665 N6*
-3670-3675 N6*
-3680-3685 N6*
-3690-3695 N6*
-37        N..8
-3900-3909 N..15
-3910-3919 N3,iso4217 N..15
-3920-3929 N..15
-3930-3939 N3,iso4217 N..15
-3940-3943 N4
-3950-3955 N6
-400       X..30
-401       X..30,key
-402       N17,csum,key
-403       X..30
-410-417   N13*,csum,key
-420       X..20
-421       N3,iso3166 X..9
-422       N3,iso3166
-423       N..15,iso3166list
-424       N3,iso3166
-425       N..15,iso3166list
-426       N3,iso3166
-427       X..3
-4300      X..35,pcenc
-4301      X..35,pcenc
-4302      X..70,pcenc
-4303      X..70,pcenc
-4304      X..70,pcenc
-4305      X..70,pcenc
-4306      X..70,pcenc
-4307      X2,iso3166alpha2
-4308      X..30
-4310      X..35,pcenc
-4311      X..35,pcenc
-4312      X..70,pcenc
-4313      X..70,pcenc
-4314      X..70,pcenc
-4315      X..70,pcenc
-4316      X..70,pcenc
-4317      X2,iso3166alpha2
-4318      X..20
-4319      X..30
-4320      X..35,pcenc
-4321      N1,yesno
-4322      N1,yesno
-4323      N1,yesno
-4324      N6,yymmd0 N4,hhmm
-4325      N6,yymmd0 N4,hhmm
-4326      N6,yymmdd
-7001      N13
-7002      X..30
-7003      N6,yymmdd N4,hhmm
-7004      N..4
-7005      X..12
-7006      N6,yymmdd
-7007      N6,yymmdd N0..6,yymmdd
-7008      X..3
-7009      X..10
-7010      X..2
-7020      X..20
-7021      X..20
-7022      X..20
-7023      X..30,key
-7030-7039 N3,iso3166999 X..27
-7040      N1 X1 X1 X1,importeridx
-710-714   X..20
-7230-7239 X2 X..28
-7240      X..20
-8001      N4,nonzero N5,nonzero N3,nonzero N1,winding N1
-8002      X..20
-8003      N1,zero N13,csum,key X0..16
-8004      X..30,key
-8005      N6
-8006      N14,csum N4,pieceoftotal
-8007      X..34,iban
-8008      N8,yymmddhh N0..4,mmoptss
-8009      X..50
-8010      C..30,key
-8011      N..12,nozeroprefix
-8012      X..20
-8013      X..25,csumalpha,key
-8017-8018 N18,csum
-8019      N..10
-8020      X..25
-8026      N14,csum N4,pieceoftotal
+00        N18*,csum,key                                     # SSCC
+01        N14*,csum,key                                     # GTIN
+02        N14*,csum,key                                     # CONTENT
+10        X..20                                             # BATCH/LOT
+11        N6*,yymmd0                                        # PROD DATE
+12        N6*,yymmd0                                        # DUE DATE
+13        N6*,yymmd0                                        # PACK DATE
+15        N6*,yymmd0                                        # BEST BEFORE or BEST BY
+16        N6*,yymmd0                                        # SELL BY
+17        N6*,yymmd0                                        # USE BY or EXPIRY
+20        N2*                                               # VARIANT
+21        X..20                                             # SERIAL
+22        X..20                                             # CPV
+235       X..28                                             # TPX
+240       X..30                                             # ADDITIONAL ID
+241       X..30                                             # CUST. PART NO.
+242       N..6                                              # MTO VARIANT
+243       X..20                                             # PCN
+250       X..30                                             # SECONDARY SERIAL
+251       X..30                                             # REF. TO SOURCE
+253       N13,csum,key X0..17                               # GDTI
+254       X..20                                             # GLN EXTENSION COMPONENT
+255       N13,csum,key N0..12                               # GCN
+30        N..8                                              # VAR. COUNT
+3100-3105 N6*                                               # NET WEIGHT (kg)
+3110-3115 N6*                                               # LENGTH (m)
+3120-3125 N6*                                               # WIDTH (m)
+3130-3135 N6*                                               # HEIGHT (m)
+3140-3145 N6*                                               # AREA (m²)
+3150-3155 N6*                                               # NET VOLUME (l)
+3160-3165 N6*                                               # NET VOLUME (m³)
+3200-3205 N6*                                               # NET WEIGHT (lb)
+3210-3215 N6*                                               # LENGTH (i)
+3220-3225 N6*                                               # LENGTH (f)
+3230-3235 N6*                                               # LENGTH (y)
+3240-3245 N6*                                               # WIDTH (i)
+3250-3255 N6*                                               # WIDTH (f)
+3260-3265 N6*                                               # WIDTH (y)
+3270-3275 N6*                                               # HEIGHT (i)
+3280-3285 N6*                                               # HEIGHT (f)
+3290-3295 N6*                                               # HEIGHT (y)
+3300-3305 N6*                                               # GROSS WEIGHT (kg)
+3310-3315 N6*                                               # LENGTH (m), log
+3320-3325 N6*                                               # WIDTH (m), log
+3330-3335 N6*                                               # HEIGHT (m), log
+3340-3345 N6*                                               # AREA (m²), log
+3350-3355 N6*                                               # VOLUME (l), log
+3360-3365 N6*                                               # VOLUME (m³), log
+3370-3375 N6*                                               # KG PER m²
+3400-3405 N6*                                               # GROSS WEIGHT (lb)
+3410-3415 N6*                                               # LENGTH (i), log
+3420-3425 N6*                                               # LENGTH (f), log
+3430-3435 N6*                                               # LENGTH (y), log
+3440-3445 N6*                                               # WIDTH (i), log
+3450-3455 N6*                                               # WIDTH (f), log
+3460-3465 N6*                                               # WIDTH (y), log
+3470-3475 N6*                                               # HEIGHT (i), log
+3480-3485 N6*                                               # HEIGHT (f), log
+3490-3495 N6*                                               # HEIGHT (y), log
+3500-3505 N6*                                               # AREA (i²)
+3510-3515 N6*                                               # AREA (f²)
+3520-3525 N6*                                               # AREA (y²)
+3530-3535 N6*                                               # AREA (i²), log
+3540-3545 N6*                                               # AREA (f²), log
+3550-3555 N6*                                               # AREA (y²), log
+3560-3565 N6*                                               # NET WEIGHT (t)
+3570-3575 N6*                                               # NET VOLUME (oz)
+3600-3605 N6*                                               # NET VOLUME (q)
+3610-3615 N6*                                               # NET VOLUME (g)
+3620-3625 N6*                                               # VOLUME (q), log
+3630-3635 N6*                                               # VOLUME (g), log
+3640-3645 N6*                                               # VOLUME (i³)
+3650-3655 N6*                                               # VOLUME (f³)
+3660-3665 N6*                                               # VOLUME (y³)
+3670-3675 N6*                                               # VOLUME (i³), log
+3680-3685 N6*                                               # VOLUME (f³), log
+3690-3695 N6*                                               # VOLUME (y³), log
+37        N..8                                              # COUNT
+3900-3909 N..15                                             # AMOUNT
+3910-3919 N3,iso4217 N..15                                  # AMOUNT
+3920-3929 N..15                                             # PRICE
+3930-3939 N3,iso4217 N..15                                  # PRICE
+3940-3943 N4                                                # PRCNT OFF
+3950-3955 N6                                                # PRICE/UoM
+400       X..30                                             # ORDER NUMBER
+401       X..30,key                                         # GINC
+402       N17,csum,key                                      # GSIN
+403       X..30                                             # ROUTE
+410       N13*,csum,key                                     # SHIP TO LOC
+411       N13*,csum,key                                     # BILL TO
+412       N13*,csum,key                                     # PURCHASE FROM
+413       N13*,csum,key                                     # SHIP FOR LOC
+414       N13*,csum,key                                     # LOC NO.
+415       N13*,csum,key                                     # PAY TO
+416       N13*,csum,key                                     # PROD/SERV LOC
+417       N13*,csum,key                                     # PARTY
+420       X..20                                             # SHIP TO POST
+421       N3,iso3166 X..9                                   # SHIP TO POST
+422       N3,iso3166                                        # ORIGIN
+423       N..15,iso3166list                                 # COUNTRY - INITIAL PROCESS
+424       N3,iso3166                                        # COUNTRY - PROCESS
+425       N..15,iso3166list                                 # COUNTRY - DISASSEMBLY
+426       N3,iso3166                                        # COUNTRY - FULL PROCESS
+427       X..3                                              # ORIGIN SUBDIVISION
+4300      X..35,pcenc                                       # SHIP TO COMP
+4301      X..35,pcenc                                       # SHIP TO NAME
+4302      X..70,pcenc                                       # SHIP TO ADD1
+4303      X..70,pcenc                                       # SHIP TO ADD2
+4304      X..70,pcenc                                       # SHIP TO SUB
+4305      X..70,pcenc                                       # SHIP TO LOC
+4306      X..70,pcenc                                       # SHIP TO REG
+4307      X2,iso3166alpha2                                  # SHIP TO COUNTRY
+4308      X..30                                             # SHIP TO PHONE
+4310      X..35,pcenc                                       # RTN TO COMP
+4311      X..35,pcenc                                       # RTN TO NAME
+4312      X..70,pcenc                                       # RTN TO ADD1
+4313      X..70,pcenc                                       # RTN TO ADD2
+4314      X..70,pcenc                                       # RTN TO SUB
+4315      X..70,pcenc                                       # RTN TO LOC
+4316      X..70,pcenc                                       # RTN TO REG
+4317      X2,iso3166alpha2                                  # RTN TO COUNTRY
+4318      X..20                                             # RTN TO POST
+4319      X..30                                             # RTN TO PHONE
+4320      X..35,pcenc                                       # SRV DESCRIPTION
+4321      N1,yesno                                          # DANGEROUS GOODS
+4322      N1,yesno                                          # AUTH LEAVE
+4323      N1,yesno                                          # SIG REQUIRED
+4324      N6,yymmd0 N4,hhmm                                 # NBEF DEL DT.
+4325      N6,yymmd0 N4,hhmm                                 # NAFT DEL DT.
+4326      N6,yymmdd                                         # REL DATE
+7001      N13                                               # NSN
+7002      X..30                                             # MEAT CUT
+7003      N6,yymmdd N4,hhmm                                 # EXPIRY TIME
+7004      N..4                                              # ACTIVE POTENCY
+7005      X..12                                             # CATCH AREA
+7006      N6,yymmdd                                         # FIRST FREEZE DATE
+7007      N6,yymmdd N0..6,yymmdd                            # HARVEST DATE
+7008      X..3                                              # AQUATIC SPECIES
+7009      X..10                                             # FISHING GEAR TYPE
+7010      X..2                                              # PROD METHOD
+7020      X..20                                             # REFURB LOT
+7021      X..20                                             # FUNC STAT
+7022      X..20                                             # REV STAT
+7023      X..30,key                                         # GIAI - ASSEMBLY
+7030-7039 N3,iso3166999 X..27                               # PROCESSOR # s
+7040      N1 X1 X1 X1,importeridx                           # UIC+EXT
+710       X..20                                             # NHRN PZN
+711       X..20                                             # NHRN CIP
+712       X..20                                             # NHRN CN
+713       X..20                                             # NHRN DRN
+714       X..20                                             # NHRN AIM
+7230-7239 X2 X..28                                          # CERT # s
+7240      X..20                                             # PROTOCOL
+8001      N4,nonzero N5,nonzero N3,nonzero N1,winding N1    # DIMENSIONS
+8002      X..20                                             # CMT NO.
+8003      N1,zero N13,csum,key X0..16                       # GRAI
+8004      X..30,key                                         # GIAI
+8005      N6                                                # PRICE PER UNIT
+8006      N14,csum N4,pieceoftotal                          # ITIP
+8007      X..34,iban                                        # IBAN
+8008      N8,yymmddhh N0..4,mmoptss                         # PROD TIME
+8009      X..50                                             # OPTSEN
+8010      C..30,key                                         # CPID
+8011      N..12,nozeroprefix                                # CPID SERIAL
+8012      X..20                                             # VERSION
+8013      X..25,csumalpha,key                               # GMN
+8017      N18,csum                                          # GSRN - PROVIDER
+8018      N18,csum                                          # GSRN - RECIPIENT
+8019      N..10                                             # SRIN
+8020      X..25                                             # REF NO.
+8026      N14,csum N4,pieceoftotal                          # ITIP CONTENT
 8110      X..70,couponcode
-8111      N4
+8111      N4                                                # POINTS
 8112      X..70,couponposoffer
-8200      X..70
-90        X..30
-91-99     X..90
+8200      X..70                                             # PRODUCT URL
+90        X..30                                             # INTERNAL
+91-99     X..90                                             # INTERNAL


### PR DESCRIPTION
Adds "# Data title" comments. Aligns them out to col 61, uses UTF-8 for squared and cubed, and expands out "410-417",  "710-714" and "8017-8018", but leaves "7030-7039" and "7230-7239", which I think are ok decisions but let us know!