### PR TITLE
gs1-format-spec: 425 -> N3..15 (same as 423)

### DIFF
--- a/contrib/development/gs1-format-spec.txt
+++ b/contrib/development/gs1-format-spec.txt
@@ -162,7 +162,7 @@
 422         N3,iso3166                                      # ORIGIN
 423         N3..15,iso3166list                              # COUNTRY - INITIAL PROCESS
 424         N3,iso3166                                      # COUNTRY - PROCESS
-425         N1..15,iso3166list                              # COUNTRY - DISASSEMBLY
+425         N3..15,iso3166list                              # COUNTRY - DISASSEMBLY
 426         N3,iso3166                                      # COUNTRY - FULL PROCESS
 427         X1..3                                           # ORIGIN SUBDIVISION
 4300        X1..35,pcenc                                    # SHIP TO COMP

--- a/src/gs1lint.ps
+++ b/src/gs1lint.ps
@@ -1262,7 +1262,7 @@ begin
         pop
 
         [
-        << /cset /N  /min  1  /max 15  /check [ /lintiso3166list ] >>
+        << /cset /N  /min  3  /max 15  /check [ /lintiso3166list ] >>
         ]
         (425) exch dup
         pop

--- a/tests/ps_tests/gs1lint.ps
+++ b/tests/ps_tests/gs1lint.ps
@@ -201,7 +201,7 @@
 ((7030)850) /bwipp.GS1valueTooShort er_tmpl
 ((7030)8501234567890123456789012345678) /bwipp.GS1valueTooLong er_tmpl
 
-% N1..15,iso3166list
+% N3..15,iso3166list
 ((423)850) good_tmpl
 ((423)004100400850894) good_tmpl
 ((423)8501) /bwipp.GS1BadCountryListLength er_tmpl


### PR DESCRIPTION
Just changes missed 425 to be same as 423 (leaving key and other possibles (e.g. iban, couponcode) alone, as agree, pedantic and not very semantic plus can always do later).