### PR TITLE
azteccode: allow for lastchar not at end in pcomp optimise

### DIFF
--- a/src/azteccode.ps
+++ b/src/azteccode.ps
@@ -290,10 +290,60 @@ begin
             lastchar () ne char 0 ge and {
                 /pchars 2 string dup 0 lastchar put dup 1 char put def
                 pcomp pchars known {
-                    curlen P get nxtlen P get lt {
-                        nxtlen P curlen P get put
-                        nxtseq P [ curseq P get aload pop pop pcomp pchars get ] put
-                    } if
+                    [ U L M P D ] {
+                        /i exch def
+                        /inP true def  % U and L can't encode CR, comma, dot or colon
+                        i M eq {  % M can encode CR
+                            lastchar 13 eq { /inP false def } if
+                        } {
+                            i D eq {  % D can encode comma and dot
+                                lastchar 44 eq lastchar 46 eq or { /inP false def } if
+                            } if
+                        } ifelse
+                        inP curlen i get nxtlen i get lt and {
+                            /curseqi curseq i get def
+                            /lastld false def
+                            /lastsp false def
+                            /lastidx -1 def
+                            curseqi length 1 sub -1 0 {  % Search backwards for lastchar
+                                /idx exch def
+                                /ch curseqi idx get def
+                                lastidx -1 eq {
+                                    ch lastchar eq {
+                                        /lastidx idx def
+                                        idx 0 gt {
+                                            curseqi idx 1 sub get sp eq { /lastsp true def } if  % Preceded by P/S
+                                        } if
+                                    } if
+                                } {  % Found lastchar, check latch
+                                    ch 0 lt ch ld ge and {  % If have latch
+                                        i P eq {
+                                            ch ld eq { /lastld true def } if  % Set flag if D/L for adjustment below
+                                        } {
+                                            ch lp ne { /inP lastsp def } if  % If not P/L only in P if have P/S
+                                        } ifelse
+                                        exit
+                                    } if
+                                } ifelse
+                            } for
+                            inP lastidx 0 ge and {
+                                nxtlen i curlen i get put
+                                lastidx curseqi length 1 sub lt {  % If lastchar not at end of sequence
+                                    i P eq {
+                                        lastld { nxtlen i nxtlen i get 1 add put } if  % Adjust count if D/L
+                                        % Move lastchar to end and replace
+                                        nxtseq i [ curseqi aload pop curseqi length lastidx sub -1 roll pop pcomp pchars get ] put
+                                    } {
+                                        % Replace lastchar in situ
+                                        nxtseq i [ curseqi aload pop ] put
+                                        nxtseq i get lastidx pcomp pchars get put
+                                    } ifelse
+                                } {
+                                    nxtseq i [ curseqi aload pop pop pcomp pchars get ] put
+                                } ifelse
+                            } if
+                        } if
+                    } forall
                 } if
             } if
 
@@ -479,7 +529,7 @@ begin
             /cwf msgbits m bpcw add 1 sub 1 getinterval def  % Last bit
             cwb allzero {/cwf (1) def /m m 1 sub def} if     % Flip last bit to avoid zeros
             cwb allones {/cwf (0) def /m m 1 sub def} if     % Flip last bit to avoid ones
-            % Concatinate the bits
+            % Concatenate the bits
             12 string dup 0 cwb putinterval
             dup bpcw 1 sub cwf putinterval
             0 bpcw getinterval
@@ -500,6 +550,8 @@ begin
         /c c 1 add def
     } loop
     /cws cws 0 c getinterval def
+
+    options /debugcws known { /bwipp.debugcws cws //raiseerror exec } if
 
     % Reed-Solomon algorithm
     /rscodes {

--- a/tests/ps_tests/azteccode.ps
+++ b/tests/ps_tests/azteccode.ps
@@ -1,0 +1,180 @@
+%!PS
+
+% ISO/IEC 24778:2008
+
+% vim: set ts=4 sw=4 et :
+
+/azteccode dup /uk.co.terryburton.bwipp findresource cvx def
+
+
+% Punctuation-space combinations
+
+{
+    (. ) (debugcws) azteccode
+} [1 7] debugIsEqual  % P/S <.SP>
+
+{
+    (^013^010) (parse debugcws) azteccode
+} [1 5] debugIsEqual  % P/S <CRLF>
+
+{
+    (. . . . . ) (debugcws) azteccode
+} [59 56 24 49 35 7] debugIsEqual  % M/L P/L <.SP>(x5)
+
+{
+    (A. ) (debugcws) azteccode  % Upper
+} [4 1 15] debugIsEqual  % "A" P/S <.SP>
+
+{
+    (A^013^010) (parse debugcws) azteccode  % Upper
+} [4 1 11] debugIsEqual  % "A" P/S <CRLF>
+
+{
+    (A. . . . . ) (debugcws) azteccode  % Upper
+} [5 55 48 49 35 6 15] debugIsEqual  % "A" M/L P/L <.SP>(x5)
+
+{
+    (A^013^010^013^010^013^010^013^010^013^010) (parse debugcws) azteccode  % Upper
+} [5 55 48 33 2 4 11] debugIsEqual  % "A" M/L P/L <CRLF>(x5)
+
+{
+    (a. ) (debugcws) azteccode  % Lower
+} [56 8 1 31] debugIsEqual  % L/L "a" P/S <.SP>
+
+{
+    (a^013^010) (parse debugcws) azteccode  % Lower
+} [56 8 1 23] debugIsEqual  % L/L "a" P/S <CRLF>
+
+{
+    (a. . . . . ) (debugcws) azteccode  % Lower
+} [56 11 47 33 35 6 12 31] debugIsEqual  % L/L "a" M/L P/L <.SP>(x5)
+
+{
+    (a^013^010^013^010^013^010^013^010^013^010) (parse debugcws) azteccode  % Lower
+} [56 11 47 33 2 4 8 23] debugIsEqual  % L/L "a" M/L P/L <CRLF>(x5)
+
+{
+    (@. ) (debugcws) azteccode  % Mixed
+} [59 16 1 31] debugIsEqual  % M/L "@" P/S <.SP>
+
+{
+    (@^013^010) (parse debugcws) azteccode  % Mixed
+} [59 17 50 62] debugIsEqual  % M/L "@" <CR> <LF>
+
+{
+    (@. . ) (debugcws) azteccode  % Mixed
+} [59 19 48 49 62] debugIsEqual  % M/L "@" P/L <.SP>(x2)
+
+{
+    (@^013^010^013^010) (parse debugcws) azteccode  % Mixed
+} [59 19 48 33 31] debugIsEqual  % M/L "@" P/L <CRLF>(x2)
+
+{
+    (@. . . . . ) (debugcws) azteccode  % Mixed
+} [59 19 48 49 35 6 15] debugIsEqual  % M/L "@" P/L <.SP>(x5)
+
+{
+    (@^013^010^013^010^013^010^013^010^013^010) (parse debugcws) azteccode  % Mixed
+} [59 19 48 33 2 4 11] debugIsEqual  % M/L "@" P/L <CRLF>(x5)
+
+{
+    (!. ) (debugcws) azteccode  % Punct.
+} [1 12 1 15] debugIsEqual  % P/S "!" P/S <.SP>
+
+{
+    (!^013^010) (parse debugcws) azteccode  % Punct.
+} [1 12 1 11] debugIsEqual  % P/S "!" P/S <CRLF>
+
+{
+    (!. . ) (debugcws) azteccode  % Punct.
+} [59 56 48 49 62] debugIsEqual  % M/L P/L "!" <.SP>(x2)
+
+{
+    (!^013^010^013^010) (parse debugcws) azteccode  % Punct.
+} [59 56 48 33 31] debugIsEqual  % M/L P/L "!" <CRLF>(x2)
+
+{
+    (!. . . . . ) (debugcws) azteccode  % Punct.
+} [59 56 48 49 35 6 15] debugIsEqual  % M/L P/L "!" <.SP>(x5)
+
+{
+    (!^013^010^013^010^013^010^013^010^013^010) (parse debugcws) azteccode  % Punct.
+} [59 56 48 33 2 4 11] debugIsEqual  % M/L P/L "!" <CRLF>(x5)
+
+{
+    (1. ) (debugcws) azteccode  % Digit
+} [60 30 35] debugIsEqual  % D/L "1" "." <SP>
+
+{
+    (1^013^010) (parse debugcws) azteccode  % Digit
+} [60 24 2] debugIsEqual  % D/L "1" P/S <CRLF>
+
+{
+    (1. . ) (debugcws) azteccode  % Digit
+} [60 30 35 40 62] debugIsEqual  % D/L "1" "." <SP> "." <SP>
+
+{
+    (1^013^010^013^010) (parse debugcws) azteccode  % Digit
+} [60 24 2 1 11] debugIsEqual  % D/L "1" P/S <CRLF> P/S <CRLF>
+
+{
+    (1. . . ) (debugcws) azteccode  % Digit
+} [60 30 35 40 58 15] debugIsEqual  % D/L "1" "." <SP> "." <SP> "." <SP>
+
+{
+    (1^013^010^013^010^013^010) (parse debugcws) azteccode  % Digit
+} [60 24 2 1 8 1 47] debugIsEqual  % D/L "1" P/S <CRLF> P/S <CRLF> P/S <CRLF>
+
+{
+    (1. . . . ) (debugcws) azteccode  % Digit
+} [60 30 35 40 58 14 35] debugIsEqual  % D/L "1" "." <SP> "." <SP> "." <SP> "." <SP>
+
+{
+    (1^013^010^013^010^013^010^013^010) (parse debugcws) azteccode  % Digit
+} [60 31 29 60 8 16 33 31] debugIsEqual  % D/L "1" U/L M/L P/L <CRLF>(x4)
+
+{
+    (1. . . . . ) (debugcws) azteccode  % Digit
+} [60 31 29 60 12 24 49 35] debugIsEqual  % D/L "1" U/L M/L P/L <.SP>(x5)
+
+{
+    (1^013^010^013^010^013^010^013^010^013^010) (parse debugcws) azteccode  % Digit
+} [60 31 29 60 8 16 33 2] debugIsEqual  % D/L "1" U/L M/L P/L <CRLF>(x5)
+
+{
+    (1, ) (debugcws) azteccode  % Digit
+} [60 30 3] debugIsEqual  % D/L "1" "," <SP>
+
+{
+    (1, , , , ) (debugcws) azteccode  % Digit
+} [60 30 3 32 56 14 3] debugIsEqual  % D/L "1" "," <SP> "," <SP> "," <SP> "," <SP>
+
+{
+    (1, , , , , ) (debugcws) azteccode  % Digit
+} [60 31 29 60 16 33 2 4] debugIsEqual  % D/L "1" U/L M/L P/L <,SP>(x5)
+
+
+% Figures
+
+{
+    (123456789012) (debugcws) azteccode  % Figure 1 (left), same
+} [60 26 10 51 49 13 22 17 41] debugIsEqual
+
+{
+    % Figure 1 (right), same
+    (Aztec Code is a public domain 2D matrix barcode symbology of nominally square symbols built on a square grid with a distinctive square bullseye pattern at their center.) (debugcws) azteccode
+} [23 55 83 16 60 36 10 96 170 129 16 99 97 181 68 9 96 225 41 254 10 113 120 23 10 179 86 66 49 76 144 41 131 77 56 112 108 17 160 192 225 124 28 167 137 173 208 105 43 10 102 13 52 225 193 180 8 236 166 212 48 120 68 26 74 194 153 130 137 168 161 194 170 144 136 37 85 42 167 146 170 185 131 73 88 83 48 71 102 182 134 209 131 17 86 166 155 194 42 134 169 50 166 18 25 245 52 253 191] debugIsEqual
+
+{
+    (Code 2D!) (debugcws) azteccode  % Figure G.2, same
+} [9 50 1 41 47 2 39 37 1 27] debugIsEqual
+
+{
+    % Figure I.1 (left), 400 1's + CRLF, same
+    (1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111^013^010) (parse debugcws) azteccode
+} [966 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 614 409 608 191] debugIsEqual
+
+{
+    % Figure I.1 (right), 400 3's + CRLF, same
+    (3333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333^013^010) (parse debugcws) azteccode
+} [970 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 682 672 191] debugIsEqual

--- a/tests/ps_tests/test.ps
+++ b/tests/ps_tests/test.ps
@@ -58,6 +58,7 @@
 [
     (../../../tests/ps_tests/parseinput.ps)
     (../../../tests/ps_tests/gs1lint.ps)
+    (../../../tests/ps_tests/azteccode.ps)
     (../../../tests/ps_tests/codeone.ps)
     (../../../tests/ps_tests/databarexpanded.ps)
     (../../../tests/ps_tests/databarexpandedstacked.ps)


### PR DESCRIPTION
The issue is that e.g. `10 100 moveto (1. . . . . ) () /azteccode /uk.co.terryburton.bwipp findresource exec` fails as the "Optimise using P compression" block doesn't take into account that the `lastchar` may not be at the end of the sequence, due to intervening latches (U/L M/L P/L), so the `pcomp` replaces the wrong character (P/L).

The proposed change addresses that by checking the position of `lastchar` and moving it to the end. It also applies the optimisation to sequences not ending in P. For instance Figure I.1 left and right in ISO/IEC 24778:2008 are now reproduced as the D/L sequence uses P/S CRLF at the end instead of U/L M/L CR LF.

But it's a fair amount of code...
