### PR TITLE
dotcode: typo add -> addtocws for Binary mode Latch C

### DIFF
--- a/src/dotcode.ps
+++ b/src/dotcode.ps
@@ -600,7 +600,7 @@ begin
             n 2 ge {
                 [ finaliseBIN ] addtocws
                 n 7 gt {  % Terminate to C
-                    [ BINvals tmc get ] add
+                    [ BINvals tmc get ] addtocws
                     /mode C def
                     exit
                 } if
@@ -726,6 +726,8 @@ begin
             nd cws length sub 1 sub {106} repeat
         ] def
     } if
+
+    options /debugcws known { /bwipp.debugcws cws //raiseerror exec } if
 
     % Create an array containing the character mappings
     /encs [

--- a/tests/ps_tests/dotcode.ps
+++ b/tests/ps_tests/dotcode.ps
@@ -1,0 +1,36 @@
+%!PS
+
+% AIM ISS DotCode, Rev 4.0, DRAFT 0.15, TSC Pre-PR #5, May 28, 2019
+
+% vim: set ts=4 sw=4 et :
+
+/dotcode dup /uk.co.terryburton.bwipp findresource cvx def
+
+/eq_tmpl {
+    3 1 roll { 0 0 dotcode /pixs get }
+    dup 3 -1 roll 1 exch put
+    dup 3 -1 roll 0 exch put
+    isEqual
+} def
+
+
+{
+    (^128^1281234567890123456) (parse debugcws) dotcode  % Binary mode Latch C
+} [112 3 14 11 111 12 34 56 78 90 12 34 56] debugIsEqual
+
+
+% Figures
+
+(2741) (dontdraw)  % Figure 7B bottom-left, auto Mask = 2', same
+[
+    1 0 1 0 0 0 1 0 1 0 1 0 1
+    0 0 0 1 0 0 0 0 0 0 0 0 0
+    1 0 0 0 1 0 0 0 1 0 1 0 1
+    0 1 0 0 0 0 0 1 0 1 0 0 0
+    0 0 0 0 1 0 1 0 0 0 1 0 0
+    0 1 0 0 0 1 0 0 0 0 0 1 0
+    1 0 0 0 1 0 1 0 1 0 0 0 1
+    0 1 0 1 0 1 0 0 0 1 0 0 0
+    1 0 0 0 1 0 0 0 1 0 1 0 1
+    0 1 0 1 0 0 0 1 0 0 0 1 0
+] eq_tmpl

--- a/tests/ps_tests/test.ps
+++ b/tests/ps_tests/test.ps
@@ -63,6 +63,7 @@
     (../../../tests/ps_tests/databarexpanded.ps)
     (../../../tests/ps_tests/databarexpandedstacked.ps)
     (../../../tests/ps_tests/datamatrix.ps)
+    (../../../tests/ps_tests/dotcode.ps)
     (../../../tests/ps_tests/gs1-cc.ps)
     (../../../tests/ps_tests/gs1datamatrix.ps)
     (../../../tests/ps_tests/gs1northamericancoupon.ps)


### PR DESCRIPTION
Typo `add` -> `addtocws` in "Terminate to C" block in `encBIN`, e.g. `10 100 moveto (^128^1281234567890123456) (parse) /dotcode /uk.co.terryburton.bwipp findresource exec` fails.