### PR TITLE
rectangularmicroqrcode: use N if all numeric, A if all alphanumeric

### DIFF
--- a/src/qrcode.ps
+++ b/src/qrcode.ps
@@ -413,7 +413,7 @@ begin
         % rMQR symbols are accessed with an explicit version
     } ifelse
 
-    % Encode unterminated bitsream for each compatible vergrp separately
+    % Encode unterminated bitstream for each compatible vergrp separately
     /msgbits [ 39 {-1} repeat ] def
     /e 10000 def
     verset {
@@ -441,8 +441,8 @@ begin
                 eci {
                     E exit
                 } if
-                ver vR7x43 ge {  % TODO rMQR is binary only for now
-                    B exit
+                ver vR7x43 ge {  % TODO rMQR is all numeric/alphanumeric/binary only for now
+                    numN msglen eq {N} { numA msglen eq {A} {B} ifelse } ifelse exit
                 } if
                 mode -1 eq {  % Set initial mode (or mode after ECI)
                     [ 1  1  1  e  e  1  1] KbeforeA {K exit} if
@@ -556,7 +556,7 @@ begin
     % Lookup the most appropriate symbol specification
     /metrics [
         % format   vers       vergrp  rows cols align modules    error codewords        error correction blocks
-        %                                                          L    M    Q    H       L1 L2 M1 M2 Q1 Q2 H1 H2
+        %                                                        L    M    Q    H       L1 L2 M1 M2 Q1 Q2 H1 H2
         [ (micro)  (M1)       vM1       11  11  98 99     36  [   2   99   99   99 ]  [  1  0 -1 -1 -1 -1 -1 -1 ] ]
         [ (micro)  (M2)       vM2       13  13  98 99     80  [   5    6   99   99 ]  [  1  0  1  0 -1 -1 -1 -1 ] ]
         [ (micro)  (M3)       vM3       15  15  98 99    132  [   6    8   99   99 ]  [  1  0  1  0 -1 -1 -1 -1 ] ]
@@ -685,7 +685,7 @@ begin
     /dcpb dcws ecb1 ecb2 add idiv def                 % Base data codewords per block
     /ecpb ncws ecb1 ecb2 add idiv dcpb sub def        % Error correction codewords per block
 
-    % Complete the message bits by adding the terminator, truncated if neccessary
+    % Complete the message bits by adding the terminator, truncated if necessary
     /term term 0 dmod msgbits length sub term length 2 copy gt {exch} if pop getinterval def
     msgbits length term length add string
     dup 0 msgbits putinterval

--- a/tests/ps_tests/rectangularmicroqrcode.ps
+++ b/tests/ps_tests/rectangularmicroqrcode.ps
@@ -27,7 +27,7 @@
 } [46 6 43 44 0 17 132 191 191 171 228 80 46 175 36 0] debugIsEqual
 
 {
-    % Table 7 R13x32-M max 61 numeric (cclen bits 7 -> 6)
+    % Table 7 R13x43-M max 61 numeric (cclen bits 7 -> 6)
     (1234567890123456789012345678901234567890123456789012345678901) (parse version=R13x43 debugcws) rectangularmicroqrcode
 } [62 143 110 70 42 6 43 53 55 10 117 70 251 208 246 228 98 160 98 179 83 112 167 84 111 189 8] debugIsEqual
 

--- a/tests/ps_tests/rectangularmicroqrcode.ps
+++ b/tests/ps_tests/rectangularmicroqrcode.ps
@@ -1,0 +1,52 @@
+%!PS
+
+% ISO/IEC JTC1/SC31N000 (Draft 2018-6-8)
+
+% vim: set ts=4 sw=4 et :
+
+/rectangularmicroqrcode dup /uk.co.terryburton.bwipp findresource cvx def
+
+/eq_tmpl {
+    3 1 roll { 0 0 rectangularmicroqrcode /pixs get }
+    dup 3 -1 roll 1 exch put
+    dup 3 -1 roll 0 exch put
+    isEqual
+} def
+
+
+% Table 3 cclens, values different from 2018-6-8 draft
+
+{
+    % Table 7 R7x43-M max 7 alphanumeric (cclen bits 4 -> 3)
+    (ABCDEFG) (version=R7x43 debugcws) rectangularmicroqrcode
+} [92 230 162 149 10 128] debugIsEqual
+
+{
+    % Annex H H.2 R11x27-H example (cclen bits 5 -> 4)
+    (0123456) (version=R11x27 eclevel=H debugecc) rectangularmicroqrcode
+} [46 6 43 44 0 17 132 191 191 171 228 80 46 175 36 0] debugIsEqual
+
+{
+    % Table 7 R13x32-M max 61 numeric (cclen bits 7 -> 6)
+    (1234567890123456789012345678901234567890123456789012345678901) (parse version=R13x43 debugcws) rectangularmicroqrcode
+} [62 143 110 70 42 6 43 53 55 10 117 70 251 208 246 228 98 160 98 179 83 112 167 84 111 189 8] debugIsEqual
+
+
+% Figures
+
+(12345678901234567890123456) (dontdraw eclevel=M version=R13x27)  % Figure 1 (data and version as here, not as given in 2018-6-8 draft)
+[
+    1 1 1 1 1 1 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 1 1
+    1 0 0 0 0 0 1 0 0 0 0 1 0 0 1 1 0 0 0 1 0 0 1 1 0 0 1
+    1 0 1 1 1 0 1 0 1 1 0 0 0 0 0 0 1 1 0 0 1 1 1 0 0 0 1
+    1 0 1 1 1 0 1 0 0 1 1 0 1 0 1 1 0 0 0 0 0 1 0 0 0 0 0
+    1 0 1 1 1 0 1 0 1 1 1 0 1 0 0 1 1 0 1 1 0 1 1 0 0 1 1
+    1 0 0 0 0 0 1 0 0 0 1 1 1 0 0 0 1 1 0 0 1 0 1 1 0 0 0
+    1 1 1 1 1 1 1 0 0 1 0 0 1 1 1 1 1 1 0 0 0 0 1 1 1 0 1
+    0 0 0 0 0 0 0 0 1 0 1 0 0 1 0 1 0 1 0 1 0 0 0 1 1 0 0
+    1 1 0 1 0 1 1 0 1 0 1 1 0 1 0 1 1 0 0 1 0 0 1 1 1 1 1
+    0 1 1 0 0 1 1 0 1 0 1 0 1 0 1 1 1 1 1 0 0 0 1 0 0 0 1
+    1 0 0 0 0 0 1 0 0 1 1 1 0 0 0 1 1 1 1 0 1 0 1 0 1 0 1
+    1 0 0 0 1 1 0 1 0 0 1 0 0 1 0 1 0 0 0 0 0 0 1 0 0 0 1
+    1 1 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 1 1 1 1
+] eq_tmpl

--- a/tests/ps_tests/test.ps
+++ b/tests/ps_tests/test.ps
@@ -72,6 +72,7 @@
     (../../../tests/ps_tests/upca.ps)
     (../../../tests/ps_tests/upce.ps)
     (../../../tests/ps_tests/qrcode.ps)
+    (../../../tests/ps_tests/rectangularmicroqrcode.ps)
     (../../../tests/ps_tests/ultracode.ps)
 ] { 1 dict begin run end } forall
 


### PR DESCRIPTION
This suggests using N mode if input all numeric, or A mode if input all alphanumeric, apart from just using B, which allows for instance reproducing Figure 1 of ISO/IEC JTC1/SC31N000 (Draft 2018-6-8).

It's also an excuse to ask if you could confirm the changes from draft 2018-6-8 to values in Table 3 "Number of bits of character count indicator" for

R7x43 alphanumeric (3 bits from 4)
R11x27 numeric (4 bits from 5)
R13x43 numeric (6 bits from 7)

(and also whether the worked example in Annex H H.2 which uses R11x27 was revised accordingly).

These changes make sense in that that's all that's needed to hold the largest possible values for these cases. However I notice that the R13x77 numeric value hasn't changed from 8 bits (7 bits would suffice for max 123 numerics).

Whenever (and if!) you get the time to confirm any of the above for me, I'd be grateful, thanks!