### PR TITLE
Add USPS FIM E mark

### DIFF
--- a/src/symbol.ps
+++ b/src/symbol.ps
@@ -83,6 +83,11 @@ begin
             /bhs [.625 .625 .625 .625 .625 .625 .625] def
             /bbs [0 0 0 0 0 0 0] def
         } bind
+        /fime {
+            /sbs [2.25 6.75 2.25 15.75 2.25 6.75 2.25] def
+            /bhs [.625 .625 .625 .625 .625 .625 .625] def
+            /bbs [0 0 0 0 0 0 0] def
+        } bind
     >> def
 
     % Valiate input


### PR DESCRIPTION
[The USPS created another FIM mark, named FIM E, with the binary code 101000101.](https://pe.usps.com/text/dmm300/202.htm#ep1123678)

I *think* I've got the encoding right - I've tested it by comparing it side-by-side (but vertically, so misaligned bars would be very noticeable) against the FIM-D (which has every bar the FIM-E does and then some) and it looks visually correct, but it's possible I've made a mistake in encoding it.

Here's an example output:
![fim-e](https://user-images.githubusercontent.com/168834/146605424-b2b79ceb-1483-4924-a82a-1833a8501d7f.png)
.