### PR TITLE
dotcode: macros: add latch B, include XX digits

### DIFF
--- a/src/dotcode.ps
+++ b/src/dotcode.ps
@@ -355,9 +355,16 @@ begin
                 } repeat
                 /inmac exch def
                 inmac 0 ne {
+                    [ Cvals lab get ] addtocws
                     /mode B def
                     [ Bvals inmac get ] addtocws
-                    /i i inmac mac ne {7} {6} ifelse add def
+                    inmac mac eq {
+                        [ Bvals msg segstart 4 add get get ] addtocws
+                        [ Bvals msg segstart 5 add get get ] addtocws
+                        /i i 6 add def
+                    } {
+                        /i i 7 add def
+                    } ifelse
                     exit
                 } if
             } if

--- a/tests/ps_tests/dotcode.ps
+++ b/tests/ps_tests/dotcode.ps
@@ -18,6 +18,14 @@
     (^128^1281234567890123456) (parse debugcws) dotcode  % Binary mode Latch C
 } [112 3 14 11 111 12 34 56 78 90 12 34 56] debugIsEqual
 
+{
+    ([\)>^03005^029101^030^004) (parse debugcws) dotcode  % Macro Latch B
+} [106 97 17 16 17] debugIsEqual
+
+{
+    ([\)>^03007Text^030^004) (parse debugcws) dotcode  % Macro XX include XX
+} [106 100 16 23 52 69 88 84 100] debugIsEqual
+
 
 % Figures
 


### PR DESCRIPTION
As the macro codewords are Code Set B, add Latch B when macro header detected (otherwise e.g. `10 100 moveto ([\)>^03005^029101^030^004) (parse) /dotcode /uk.co.terryburton.bwipp findresource exec` and `50 100 moveto ((97)171617) () /gs1dotcode /uk.co.terryburton.bwipp findresource exec` give the same result).

Also add the XX digits for macro 100 which were being skipped (could alternatively adjust the increment to `i` from 6 to 4 and leave encoding them to the loop but thinking it's probably clearer to deal with them immediately (also matches what Zint produces!)).