### PR TITLE
dotcode: handle Shift B CRLF in encC and encA

### DIFF
--- a/src/dotcode.ps
+++ b/src/dotcode.ps
@@ -445,8 +445,13 @@ begin
             } if
             [ Cvals [ sfb sb2 sb3 sb4 ] n 1 sub get get ] addtocws
             n {
-                [ Bvals msg i get get ] addtocws
-                /i i 1 add def
+                msg i get 13 eq {
+                    [ Bvals crl get ] addtocws
+                    /i i 2 add def
+                } {
+                    [ Bvals msg i get get ] addtocws
+                    /i i 1 add def
+                } ifelse
             } repeat
             exit
         } repeat
@@ -594,8 +599,13 @@ begin
             } if
             [ Avals [ sfb sb2 sb3 sb4 sb5 sb6 ] n 1 sub get get ] addtocws
             n {
-                [ Bvals msg i get get ] addtocws
-                /i i 1 add def
+                msg i get 13 eq {
+                    [ Bvals crl get ] addtocws
+                    /i i 2 add def
+                } {
+                    [ Bvals msg i get get ] addtocws
+                    /i i 1 add def
+                } ifelse
             } repeat
             exit
         } repeat

--- a/tests/ps_tests/dotcode.ps
+++ b/tests/ps_tests/dotcode.ps
@@ -26,6 +26,14 @@
     ([\)>^03007Text^030^004) (parse debugcws) dotcode  % Macro XX include XX
 } [106 100 16 23 52 69 88 84 100] debugIsEqual
 
+{
+    (12a^013^010) (parse debugcws) dotcode  % Shift B CRLF in Code Set A
+} [107 12 103 65 96] debugIsEqual
+
+{
+    (^001a^009^013^010) (parse debugcws) dotcode  % Shift B CRLF in Code Set C
+} [101 65 98 65 97 96] debugIsEqual
+
 
 % Figures
 


### PR DESCRIPTION
Handles CRLF when doing Shift B in Code Set C or A, otherwise e.g. `10 100 moveto (12a^013^010) (parse) /dotcode /uk.co.terryburton.bwipp findresource exec` and `10 100 moveto (^001a^009^013^010) (parse) /dotcode /uk.co.terryburton.bwipp findresource exec` will fail.