### PR TITLE
qrcode: calculate numBs from "not others" to avoid Kanji overlap

### DIFF
--- a/src/qrcode.ps
+++ b/src/qrcode.ps
@@ -139,15 +139,7 @@ begin
         ] {-1} forall
     >> def
 
-    /Bexcl <<
-        [
-            16#00 1 16#1F {} for
-            16#21 16#22 16#23 16#26 16#27 16#28 16#29 16#2C
-            16#3B 1 16#40 {} for
-            16#5B 1 16#7F {} for
-            16#A0 1 16#DF {} for
-        ] {-1} forall
-    >> def
+    % Binary exclusives calculated from "not others"
 
     /Kexcl <<
         [
@@ -358,12 +350,6 @@ begin
         } {
             nextNs i nextNs i 1 add get 1 add put
         } ifelse
-        Bexcl barchar known {
-            nextBs i 0 put
-            numBs i numBs i 1 add get 1 add put
-        } {
-            nextBs i nextBs i 1 add get 1 add put
-        } ifelse
         Aexcl barchar known {
             nextAs i 0 put
             numAs i numAs i 1 add get 1 add put
@@ -379,6 +365,15 @@ begin
             numKs i 1 add 0 put
             nextKs i 1 add nextKs i 1 add get 1 add put
         } if
+    } for
+    msglen 1 sub -1 0 {  % Finally scan backwards again to set numBs/nextBs from "not others"
+        /i exch def
+        numNs i get numAs i get numKs i get add add 0 eq {
+            nextBs i 0 put
+            numBs i numBs i 1 add get 1 add put
+        } {
+            nextBs i nextBs i 1 add get 1 add put
+        } ifelse
     } for
 
     /KbeforeB {numK exch ver get ge nextBs numK 2 mul i add get 0 eq and} bind def

--- a/tests/ps_tests/microqrcode.ps
+++ b/tests/ps_tests/microqrcode.ps
@@ -14,6 +14,17 @@
 } def
 
 
+% numBs calculation
+
+{  % B1
+    (^128) (parse debugcws) microqrcode
+} [134 0 0 236 17 236 17 236 17 236 0] debugIsEqual
+
+{  % B1 in Kanji 1st byte range
+    (^129) (parse debugcws) microqrcode
+} [134 4 0 236 17 236 17 236 17 236 0] debugIsEqual
+
+
 % Encodation examples
 
 {


### PR DESCRIPTION
The `Bexcl` set was missing `0xA0` and `0xEC-0xFF` which would cause e.g. `10 100 moveto (^128) (parse) /microqrcode /uk.co.terryburton.bwipp findresource exec` to fail as the `numBs` would be zero causing the M1 and M2 versions not to be excluded in the "Derive optimal sequence" loop.

Rather than just add the missing values, the proposed change removes `Bexcl` altogether and instead sets `numBs` (and `nextBs`) in a post-loop based on the other exclusive sets. This has the advantage of not having to account for whether byte sequences overlap with Kanji or not, and should therefore be accurate.