### PR TITLE
qrcode: ECI regression fix (PR #179 [88510ab])

### DIFF
--- a/src/qrcode.ps
+++ b/src/qrcode.ps
@@ -368,7 +368,7 @@ begin
     } for
     msglen 1 sub -1 0 {  % Finally scan backwards again to set numBs/nextBs from "not others"
         /i exch def
-        numNs i get numAs i get numKs i get add add 0 eq {
+        numNs i get numAs i get numKs i get add add 0 eq isECI i get not and {
             nextBs i 0 put
             numBs i numBs i 1 add get 1 add put
         } {

--- a/tests/ps_tests/qrcode.ps
+++ b/tests/ps_tests/qrcode.ps
@@ -32,6 +32,10 @@
     (?^130^226^130^226^130^226^130^226w^130^226^130^226^130^226^130^226 ^130^226^130^226^130^226^130^226^130^226) (parse version=2 eclevel=L debugcws) qrcode
 } [65 51 248 46 40 46 40 46 40 46 39 120 46 40 46 40 46 40 46 34 8 5 11 16 88 130 196 22 32 177 0 236 17 236] debugIsEqual
 
+{  % ECI regression fix (PR #179 calculate numBs from "not others" to avoid Kanji overlap [88510ab])
+    (^182^ECI000007^182) (parse parsefnc version=1 eclevel=H debugcws) qrcode
+} [64 27 103 7 64 27 96 236 17] debugIsEqual
+
 
 % Figures
 


### PR DESCRIPTION
Fixes regression introduced by PR https://github.com/bwipp/postscriptbarcode/pull/179 not taking into account ECIs - needs to exclude `isECI` also in `numBs`/`nextBs` calculation loop (sigh).