### PR TITLE
bc412: semi: SEMI T1-95 check digit calc & pos

### DIFF
--- a/src/bc412.ps
+++ b/src/bc412.ps
@@ -81,7 +81,7 @@ begin
     /height height cvr def
 
     semi {
-        /includecheck true def
+        % Implies includecheck and includecheckintext also
         /includestartstop true def
     } if
 
@@ -101,21 +101,63 @@ begin
         } if
     } for
 
-    /barlen barcode length validatecheck {1 sub} if def
+    semi {
+        % Validate length
+        validatecheck {
+            barcode length 8 lt barcode length 19 gt or {
+                /bwipp.bc412semivalidateBadLength (BC412 semi with check digit must be 8 to 19 characters long) //raiseerror exec
+            } if
+        } {
+            barcode length 7 lt barcode length 18 gt or {
+                /bwipp.bc412semiBadLength (BC412 semi must be 7 to 18 characters long) //raiseerror exec
+            } if
+        } ifelse
 
-    /checksum 0 def
-    0 1 barlen 1 sub {
-        barcode exch 1 getinterval charvals exch get
-        checksum add /checksum exch def
-    } for
-    /checksum checksum 35 mod def
-    validatecheck {
-        barcode barlen get barchars checksum get ne {
-            /bwipp.bc412badCheckDigit (Incorrect BC412 check digit provided) //raiseerror exec
+        /barlen barcode length def
+        validatecheck not {  % Place dummy (0) in checksum position (1-based 2nd)
+            /barlen barlen 1 add def
+            /sbarcode barlen string def
+            sbarcode 0 barcode 0 get put
+            sbarcode 1 48 put  % (0)
+            sbarcode 2 barcode 1 barlen 2 sub getinterval putinterval
+            /barcode sbarcode def
         } if
-        /barcode barcode 0 barlen getinterval def
-        /includecheck true def
-    } if
+        /sumodd 0 def /sumeven 0 def
+        0 1 barlen 1 sub {
+            /i exch def
+            barcode i 1 getinterval charvals exch get
+            i 2 mod 0 eq {  % 1-based odd
+                sumodd add /sumodd exch def
+            } {
+                sumeven add /sumeven exch def
+            } ifelse
+        } for
+        /checksum sumodd 35 mod sumeven 35 mod 2 mul add 35 mod def  % F = Mod35( Mod35( Fodd ) + 2 * Mod35( Feven ) )
+        validatecheck {
+            checksum 0 ne {
+                /bwipp.bc412semiBadCheckDigit (Incorrect BC412 semi check digit provided) //raiseerror exec
+            } if
+        } {
+            /checksum checksum 17 mul 35 mod def  % CD = Mod35( 17 * F )
+            barcode 1 barchars checksum get put
+        } ifelse
+    } {
+        /barlen barcode length validatecheck {1 sub} if def
+
+        /checksum 0 def
+        0 1 barlen 1 sub {
+            barcode exch 1 getinterval charvals exch get
+            checksum add /checksum exch def
+        } for
+        /checksum checksum 35 mod def
+        validatecheck {
+            barcode barlen get barchars checksum get ne {
+                /bwipp.bc412badCheckDigit (Incorrect BC412 check digit provided) //raiseerror exec
+            } if
+            /barcode barcode 0 barlen getinterval def
+            /includecheck true def
+        } if
+    } ifelse
 
     % Create an array containing the character mappings
 {
@@ -170,7 +212,7 @@ begin
     % Put the stop character
     includestartstop {
         sbs pos encs 36 get putinterval
-        /pos pos 2 add def
+        /pos pos 3 add def
     } if
 
     % Return the arguments

--- a/tests/ps_tests/bc412.ps
+++ b/tests/ps_tests/bc412.ps
@@ -1,0 +1,105 @@
+%!PS
+
+% SEMI T1-95 (1996)
+
+% vim: set ts=4 sw=4 et :
+
+/bc412 dup /uk.co.terryburton.bwipp findresource cvx def
+
+/eq_tmpl_semi {
+    exch { 0 (dontdraw semi) bc412 /sbs get } dup 3 -1 roll 0 exch put
+    exch isEqual
+} def
+/er_tmpl_semi {
+    exch { 0 (dontdraw semi) bc412 /sbs get } dup 3 -1 roll 0 exch put
+    exch isError
+} def
+
+/eq_tmpl_semi_validate {
+    exch { 0 (dontdraw semi validatecheck) bc412 /sbs get } dup 3 -1 roll 0 exch put
+    exch isEqual
+} def
+/er_tmpl_semi_validate {
+    exch { 0 (dontdraw semi validatecheck) bc412 /sbs get } dup 3 -1 roll 0 exch put
+    exch isError
+} def
+
+/eq_tmpl {
+    exch { 0 (dontdraw includestartstop includecheck) bc412 /sbs get } dup 3 -1 roll 0 exch put
+    exch isEqual
+} def
+/er_tmpl {
+    exch { 0 (dontdraw includestartstop includecheck) bc412 /sbs get } dup 3 -1 roll 0 exch put
+    exch isError
+} def
+
+/eq_tmpl_validate {
+    exch { 0 (dontdraw includestartstop validatecheck) bc412 /sbs get } dup 3 -1 roll 0 exch put
+    exch isEqual
+} def
+/er_tmpl_validate {
+    exch { 0 (dontdraw includestartstop validatecheck) bc412 /sbs get } dup 3 -1 roll 0 exch put
+    exch isError
+} def
+
+
+% SEMI T1-95 Figure 2
+(AQ45670)  % A           Q               Q               4               5               6               7               0               Stop
+    [1 2 1 1 1 3 1 2 1 2 1 3 1 1 1 1 1 3 1 3 1 1 1 1 1 3 1 1 1 1 1 5 1 1 1 1 1 2 1 1 1 4 1 1 1 2 1 2 1 3 1 1 1 2 1 3 1 2 1 1 1 1 1 1 1 5 1 1 1]
+    eq_tmpl_semi
+
+(AQQ45670)
+    [1 2 1 1 1 3 1 2 1 2 1 3 1 1 1 1 1 3 1 3 1 1 1 1 1 3 1 1 1 1 1 5 1 1 1 1 1 2 1 1 1 4 1 1 1 2 1 2 1 3 1 1 1 2 1 3 1 2 1 1 1 1 1 1 1 5 1 1 1]
+    eq_tmpl_semi_validate
+
+(A2Q45670)
+    /bwipp.bc412semiBadCheckDigit
+    er_tmpl_semi_validate
+
+(AQ45670)  % A           Q               4               5               6               7               0               L               Stop
+    [1 2 1 1 1 3 1 2 1 2 1 3 1 1 1 1 1 3 1 1 1 1 1 5 1 1 1 1 1 2 1 1 1 4 1 1 1 2 1 2 1 3 1 1 1 2 1 3 1 2 1 1 1 1 1 1 1 5 1 2 1 2 1 3 1 1 1 1 1]
+    eq_tmpl
+
+(AQ45670L)
+    [1 2 1 1 1 3 1 2 1 2 1 3 1 1 1 1 1 3 1 1 1 1 1 5 1 1 1 1 1 2 1 1 1 4 1 1 1 2 1 2 1 3 1 1 1 2 1 3 1 2 1 1 1 1 1 1 1 5 1 2 1 2 1 3 1 1 1 1 1]
+    eq_tmpl_validate
+
+(AQ45670V)
+    /bwipp.bc412badCheckDigit
+    er_tmpl_validate
+
+(1234567890ABCDEFGH)  % 18 max len
+    [1 2 1 1 1 1 1 2 1 4 1 2 1 1 1 4 1 1 1 1 1 1 1 3 1 3 1 1 1 1 1 4 1 2 1 1 1 1 1 5 1 1 1 1 1 2 1 1 1 4 1 1 1 2 1 2 1 3 1 1 1 2 1 3 1 2 1 1 1 2 1 4 1 1 1 1 1 3 1 1 1 3 1 1 1 1 1 1 1 5 1 1 1 3 1 2 1 2 1 1 1 3 1 3 1 1 1 1 1 4 1 1 1 2 1 1 1 4 1 2 1 1 1 1 1 5 1 1 1 1 1 2 1 1 1 1 1 4 1 2 1 1 1 2 1 3 1 2 1 1 1 3 1 2 1 1 1]
+    eq_tmpl_semi
+
+(1I234567890ABCDEFGH)  % 19 max len with check digit
+    [1 2 1 1 1 1 1 2 1 4 1 2 1 1 1 4 1 1 1 1 1 1 1 3 1 3 1 1 1 1 1 4 1 2 1 1 1 1 1 5 1 1 1 1 1 2 1 1 1 4 1 1 1 2 1 2 1 3 1 1 1 2 1 3 1 2 1 1 1 2 1 4 1 1 1 1 1 3 1 1 1 3 1 1 1 1 1 1 1 5 1 1 1 3 1 2 1 2 1 1 1 3 1 3 1 1 1 1 1 4 1 1 1 2 1 1 1 4 1 2 1 1 1 1 1 5 1 1 1 1 1 2 1 1 1 1 1 4 1 2 1 1 1 2 1 3 1 2 1 1 1 3 1 2 1 1 1]
+    eq_tmpl_semi_validate
+
+(1X234567890ABCDEFGH)  % Invalid check
+    /bwipp.bc412semiBadCheckDigit
+    er_tmpl_semi_validate
+
+(1234567890ABCDEFGHI)  % 19 len too long
+    /bwipp.bc412semiBadLength
+    er_tmpl_semi
+
+(1I234567890ABCDEFGHI)  % 20 len too long with check digit
+    /bwipp.bc412semivalidateBadLength
+    er_tmpl_semi_validate
+
+(123456)  % 6 len too short
+    /bwipp.bc412semiBadLength
+    er_tmpl_semi
+
+(1234567)  % 7 len too short with check digit
+    /bwipp.bc412semivalidateBadLength
+    er_tmpl_semi_validate
+
+(ABCDEFGHIJKLMNO)  % Letter O not allowed
+    /bwipp.bc412badCharacter
+    er_tmpl
+
+(ABCDEFGHIJKLMNO)
+    /bwipp.bc412badCharacter
+    er_tmpl_semi

--- a/tests/ps_tests/test.ps
+++ b/tests/ps_tests/test.ps
@@ -59,6 +59,7 @@
     (../../../tests/ps_tests/parseinput.ps)
     (../../../tests/ps_tests/gs1lint.ps)
     (../../../tests/ps_tests/azteccode.ps)
+    (../../../tests/ps_tests/bc412.ps)
     (../../../tests/ps_tests/code93ext.ps)
     (../../../tests/ps_tests/codeone.ps)
     (../../../tests/ps_tests/databarexpanded.ps)


### PR DESCRIPTION
For bc412 `(semi)` implements check digit calculation and placement (2nd char) based on SEMI T1-95 spec, with length 7-18 validation.

Also stop char length typo 2 -> 3.