### PR TITLE
qrcode optimize: partly addresses bwipp-js #237 by adding A or N inclusive sum

### DIFF
--- a/contrib/development/build-qr-mode-optim-arrs.php
+++ b/contrib/development/build-qr-mode-optim-arrs.php
@@ -194,6 +194,12 @@ for ($i = 0; $i < 3; $i++) $arr[] = 1;
 for ($i = 0; $i < 4; $i++) $arr[] = $mqr[QR_A][$i] == -1 ? -1 : 1;
 for ($i = 0; $i < 32; $i++) $arr[] = 1;
 print_arr('mode0forceA', $arr);
+
+$arr = array(); /* mode0forceN */
+for ($i = 0; $i < 3; $i++) $arr[] = 1;
+for ($i = 0; $i < 4; $i++) $arr[] = 1;
+for ($i = 0; $i < 32; $i++) $arr[] = 1;
+print_arr('mode0forceN', $arr);
 print PHP_EOL;
 
 /* mode0KbeforeB same as modeBKbeforeE so omit */
@@ -220,11 +226,9 @@ set_and_print_arr('modeBKbeforeB', BITS_CHAR_MAX / 2,
         return $qr[QR_K][$i] + $bits[QR_K][$j] + $qr[QR_B][$i] < $bits[QR_B][$j * 2];
     }, function ($i) use ($mqr) {
         return $mqr[QR_B][$i] == -1 || $mqr[QR_K][$i] == -1;
-    },
-    function ($i, $j) use ($mqr, $bits) {
+    }, function ($i, $j) use ($mqr, $bits) {
         return $mqr[QR_K][$i] + $bits[QR_K][$j] + $mqr[QR_B][$i] < $bits[QR_B][$j * 2];
-    },
-    function ($i, $j) use ($rmqr, $bits) {
+    }, function ($i, $j) use ($rmqr, $bits) {
         return $rmqr[QR_K][$i] + $bits[QR_K][$j] + $rmqr[QR_B][$i] < $bits[QR_B][$j * 2];}
 );
 set_and_print_arr('modeBKbeforeA', BITS_CHAR_MAX / 2,

--- a/src/qrcode.ps
+++ b/src/qrcode.ps
@@ -332,6 +332,7 @@ begin
 
     /numNs [ msglen {0} repeat 0 ] def
     /numAs [ msglen {0} repeat 0 ] def
+    /numAorNs [ msglen {0} repeat 0 ] def
     /numBs [ msglen {0} repeat 0 ] def
     /numKs [ msglen {0} repeat 0 ] def
     /nextNs [ msglen {0} repeat 9999 ] def
@@ -356,12 +357,14 @@ begin
         Nexcl barchar known {
             nextNs i 0 put
             numNs i numNs i 1 add get 1 add put
+            numAorNs i numAorNs i 1 add get 1 add put
         } {
             nextNs i nextNs i 1 add get 1 add put
         } ifelse
         Aexcl barchar known {
             nextAs i 0 put
             numAs i numAs i 1 add get 1 add put
+            numAorNs i numAorNs i 1 add get 1 add put
         } {
             nextAs i nextAs i 1 add get 1 add put
         } ifelse
@@ -396,6 +399,10 @@ begin
     /NbeforeB {numN exch ver get ge nextBs numN i add get 0 eq and} def
     /NbeforeA {numN exch ver get ge nextAs numN i add get 0 eq and} def
     /NbeforeE {numN exch ver get ge numN i add msglen eq and} def
+    /AorNbeforeB {numAorN exch ver get ge nextBs numAorN i add get 0 eq and} def
+    /AorNbeforeE {numAorN exch ver get ge numAorN i add msglen eq and} def
+
+    /nextNslt { nextNs i get msglen ge { pop true } { numNs nextNs i get i add get exch ver get lt } ifelse } def
 
     % Elements of the encoded message have differing lengths based on the
     % resulting symbol size. The symbol sizes with different element lengths
@@ -445,6 +452,7 @@ begin
 {
     /mode0forceKB  [ 1  1  1  e e 1 1  1 1 1 1 1  1 1 1 1  1   1 1 1 1  1  1   1 1 1  1  1  1   1  1  1  1  1   1  1  1  1  1] def
     /mode0forceA   [ 1  1  1  e 1 1 1  1 1 1 1 1  1 1 1 1  1   1 1 1 1  1  1   1 1 1  1  1  1   1  1  1  1  1   1  1  1  1  1] def
+    /mode0forceN   [ 1  1  1  1 1 1 1  1 1 1 1 1  1 1 1 1  1   1 1 1 1  1  1   1 1 1  1  1  1   1  1  1  1  1   1  1  1  1  1] def
 
     /mode0NbeforeB [ 4  4  5  e e 2 3  2 2 3 3 3  2 3 3 3  3   2 3 3 3  3  3   2 3 3  3  3  3   3  3  3  3  3   3  3  3  3  3] def
 
@@ -478,6 +486,7 @@ begin
             /numB numBs i get def
             /numA numAs i get def
             /numN numNs i get def
+            /numAorN numAorNs i get def
             /eci isECI i get def
             ver vM1 eq numA 1 ge and {/seq -1 def exit} if
             ver vM1 eq numB 1 ge and {/seq -1 def exit} if
@@ -498,18 +507,13 @@ begin
                     modeBKbeforeE KbeforeB {K exit} if  % Re-using modeB KbeforeE array
                     mode0forceKB  KbeforeE {K exit} if
                     numK 1 ge {B exit} if
-                    modeBAbeforeE AbeforeK {A exit} if  % Re-using modeB AbeforeE array
-                    modeBAbeforeE AbeforeB {A exit} if  % Re-using modeB AbeforeE array
-                    mode0forceA   AbeforeN {A exit} if
-                    mode0forceA   AbeforeE {A exit} if
-                    numA 1 ge {
-                        ver vM2 ne {B} {A} ifelse exit
-                    } if
                     mode0NbeforeB NbeforeB {N exit} if
                     mode0forceKB  NbeforeB {B exit} if
                     modeANbeforeE NbeforeA {N exit} if  % Re-using modeA NbeforeE array
-                    mode0forceA   NbeforeA {A exit} if
-                    numN 1 ge {N exit} if
+                    mode0forceN   NbeforeE {N exit} if
+                    modeBAbeforeE AbeforeK {A exit} if  % Re-using modeB AbeforeE array
+                    modeBAbeforeE AorNbeforeB {A exit} if  % Re-using modeB AbeforeE array
+                    mode0forceA   AorNbeforeE {A exit} if
                     B exit
                 } if
                 mode B eq {
@@ -525,6 +529,9 @@ begin
                     modeBNbeforeB NbeforeB {N exit} if
                     modeBNbeforeA NbeforeA {N exit} if
                     modeBNbeforeE NbeforeE {N exit} if
+                    modeBAbeforeE AorNbeforeE numAorN modeBAbeforeN ver get le and {  % If A/N sequence at end and short
+                        modeBNbeforeA nextNslt {A exit} if  % And next N sequence shorter than NbeforeA
+                    } if
                     B exit
                 } if
                 mode A eq {

--- a/tests/ps_tests/microqrcode.ps
+++ b/tests/ps_tests/microqrcode.ps
@@ -13,6 +13,13 @@
     isEqual
 } def
 
+/er_tmpl {
+    3 1 roll { 0 0 microqrcode /pixs get }
+    dup 3 -1 roll 1 exch put
+    dup 3 -1 roll 0 exch put
+    exch isError
+} def
+
 
 % numBs calculation
 
@@ -66,6 +73,69 @@
     % A3 K1 (ABC点), new initial mode A before K re-using modeBAbeforeE array, previously B5 (longer msgbits length)
     (ABC^147^095) (parse version=M3 eclevel=L debugcws) microqrcode
 } [76 230 153 150 207 128 236 17 236 17 0] debugIsEqual
+
+{
+    % B14, issue #237, initial AN, removal of mode0forceA AbeforeN, previously not encodable A2 B12
+    (K9^000^000^000^000^000^000^000^000^000^000^000^000^000) (parse debugcws) microqrcode
+} [79 75 57 0 0 0 0 0 0 0 0 0 0 0 0 0] debugIsEqual
+{
+    % B14, issue #237, initial NA, removal of numN 1 ge test, previously not encodable A2 B12
+    (9K^000^000^000^000^000^000^000^000^000^000^000^000^000) (parse debugcws) microqrcode
+} [79 57 75 0 0 0 0 0 0 0 0 0 0 0 0 0] debugIsEqual
+
+{
+    % B14, initial ANA
+    (K9K^000^000^000^000^000^000^000^000^000^000^000^000) (parse debugcws) microqrcode
+} [79 75 57 75 0 0 0 0 0 0 0 0 0 0 0 0] debugIsEqual
+{
+    % B14, inversion of above
+    (^000^000^000^000^000^000^000^000^000^000^000^000K9K) (parse debugcws) microqrcode
+} [79 0 0 0 0 0 0 0 0 0 0 0 0 75 57 75] debugIsEqual
+
+{
+    % A4 B11, issue #237, initial ANAN, new AorN before B re-using modeBAbeforeE array
+    % (needed after removals mentioned above), previously the same
+    (K9K9^000^000^000^000^000^000^000^000^000^000^000) (parse debugcws) microqrcode
+} [36 113 174 53 44 0 0 0 0 0 0 0 0 0 0 0] debugIsEqual
+{
+    % B11 A4, inversion of above
+    (^000^000^000^000^000^000^000^000^000^000^000K9K9) (parse debugcws) microqrcode
+} [75 0 0 0 0 0 0 0 0 0 0 0 36 113 174 52] debugIsEqual
+
+{
+    % A7 B9, initial ANANANA
+    (K9K9K9K^000^000^000^000^000^000^000^000^000) (parse debugcws) microqrcode
+} [39 113 174 53 198 168 146 0 0 0 0 0 0 0 0 0] debugIsEqual
+{
+    % B9 A7, inversion of above, new mode B terminal short AorN sequence
+    (^000^000^000^000^000^000^000^000^000K9K9K9K) (parse debugcws) microqrcode
+} [73 0 0 0 0 0 0 0 0 0 39 113 174 53 198 168] debugIsEqual
+{
+    % B9 A7, with AorN sequence containg N3
+    (^000^000^000^000^000^000^000^000^000KK999KK) (parse debugcws) microqrcode
+} [73 0 0 0 0 0 0 0 0 0 39 115 6 120 212 168] debugIsEqual
+    % With AorN sequence containing N4 fails with unencodable B11 N4 A1 (due to next N sequence shorter than NbeforeA)
+    (^000^000^000^000^000^000^000^000^000KK9999K) (parse dontdraw) /bwipp.qrcodeNoValidSymbol er_tmpl
+
+{
+    % A8 B8, initial ANANANAN
+    (K9K9K9K9^000^000^000^000^000^000^000^000) (parse debugcws) microqrcode
+} [40 113 174 53 198 184 212 128 0 0 0 0 0 0 0 0] debugIsEqual
+{
+    % B8 A8, inversion of above
+    (^000^000^000^000^000^000^000^000K9K9K9K9) (parse debugcws) microqrcode
+} [72 0 0 0 0 0 0 0 0 40 113 174 53 198 184 208] debugIsEqual
+
+{
+    % A10 B7, initial ANANANANAN
+    (K9K9K9K9K9^000^000^000^000^000^000^000) (parse debugcws) microqrcode
+} [42 113 174 53 198 184 215 26 142 0 0 0 0 0 0 0] debugIsEqual
+    % Inversion of above fails with unencodable B9 A8 (terminal AorN sequence too long to produce B7 A10)
+    (^000^000^000^000^000^000^000K9K9K9K9K9) (parse dontdraw) /bwipp.qrcodeNoValidSymbol er_tmpl
+{
+    % B7 A9, one less works
+    (^000^000^000^000^000^000^000K9K9K9K9K) (parse debugcws) microqrcode
+} [72 0 0 0 0 0 0 0 75 40 53 38 164 212 154 144] debugIsEqual
 
 
 % Figures

--- a/tests/ps_tests/qrcode.ps
+++ b/tests/ps_tests/qrcode.ps
@@ -13,6 +13,13 @@
     isEqual
 } def
 
+/er_tmpl {
+    3 1 roll { 0 0 qrcode /pixs get }
+    dup 3 -1 roll 1 exch put
+    dup 3 -1 roll 0 exch put
+    exch isError
+} def
+
 
 {
     (TESTING) (debugcws) qrcode
@@ -77,6 +84,42 @@
     % A6 K1 (ABCDEF点), new initial mode A before K re-using modeBAbeforeE array, previously B8 (longer msgbits length)
     (ABCDEF^147^095) (parse version=1 eclevel=L debugcws) qrcode
 } [32 49 205 69 42 22 0 91 62 0 236 17 236 17 236 17 236 17 236] debugIsEqual
+
+{
+    % B17, issue #237, previously unencodable A3 B14
+    (K9K^000^000^000^000^000^000^000^000^000^000^000^000^000^000) (parse version=1 eclevel=L debugcws) qrcode
+} [65 20 179 148 176 0 0 0 0 0 0 0 0 0 0 0 0 0 0] debugIsEqual
+{
+    % B17, inversion of above
+    (^000^000^000^000^000^000^000^000^000^000^000^000^000^000K9K) (parse version=1 eclevel=L debugcws) qrcode
+} [65 16 0 0 0 0 0 0 0 0 0 0 0 0 0 4 179 148 176] debugIsEqual
+
+{
+    % A10 B9
+    (K9K9K9K9K9^000^000^000^000^000^000^000^000^000) (parse version=1 eclevel=L debugcws) qrcode
+} [32 83 141 113 174 53 198 184 212 9 0 0 0 0 0 0 0 0 0] debugIsEqual
+{
+    % B9 A10, inversion of above
+    (^000^000^000^000^000^000^000^000^000K9K9K9K9K9) (parse version=1 eclevel=L debugcws) qrcode
+} [64 144 0 0 0 0 0 0 0 0 2 5 56 215 26 227 92 107 141] debugIsEqual
+
+{
+    % B9 A10, with AorN sequence containing N5
+    (^000^000^000^000^000^000^000^000^000K99999K9KK) (parse version=1 eclevel=L debugcws) qrcode
+} [64 144 0 0 0 0 0 0 0 0 2 5 56 211 60 103 156 107 152] debugIsEqual
+    % With AorN sequence containing N6 fails with unencodable B10 N6 A3 (due to nextNslt test)
+    (^000^000^000^000^000^000^000^000^000K999999KKK) (parse version=1 eclevel=L dontdraw) /bwipp.qrcodeNoValidSymbol er_tmpl
+
+{
+    % A14 B6
+    (K9K9K9K9K9K9K9^000^000^000^000^000^000) (parse version=1 eclevel=L debugcws) qrcode
+} [32 115 141 113 174 53 198 184 215 26 227 80 24 0 0 0 0 0 0] debugIsEqual
+    % Inversion of above fails with unencodable B8 A12 (terminal AorN sequence too long to produce B6 A14)
+    (^000^000^000^000^000^000K9K9K9K9K9K9K9) (parse version=1 eclevel=L dontdraw) /bwipp.qrcodeNoValidSymbol er_tmpl
+{
+    % One less fits with B7 A12, though longer msgbits length than B6 A13
+    (^000^000^000^000^000^000K9K9K9K9K9K9K) (parse version=1 eclevel=L debugcws) qrcode
+} [64 112 0 0 0 0 0 4 178 6 26 147 82 106 77 73 169 53 32] debugIsEqual
 
 
 % Figures

--- a/tests/ps_tests/rectangularmicroqrcode.ps
+++ b/tests/ps_tests/rectangularmicroqrcode.ps
@@ -13,6 +13,13 @@
     isEqual
 } def
 
+/er_tmpl {
+    3 1 roll { 0 0 rectangularmicroqrcode /pixs get }
+    dup 3 -1 roll 1 exch put
+    dup 3 -1 roll 0 exch put
+    exch isError
+} def
+
 
 % Table 3 cclens, 2019-10-18 values different from 2018-6-8 draft
 
@@ -65,6 +72,37 @@
     % 7.4.6 Kanji mode (点茗点), R7x43-M, 3 Kanji max (Table 6)
     (^147^095^228^170^147^095) (parse version=R7x43 eclevel=M debugcws) rectangularmicroqrcode
 } [155 103 245 84 217 240] debugIsEqual
+
+{
+    % B14, issue #237, previously unencodable A2 B12
+    (K9^000^000^000^000^000^000^000^000^000^000^000^000) (parse version=R11x59 eclevel=H debugcws) rectangularmicroqrcode
+} [110 75 57 0 0 0 0 0 0 0 0 0 0 0 0] debugIsEqual
+{
+    % B14, inversion of above
+    (^000^000^000^000^000^000^000^000^000^000^000^000K9) (parse version=R11x59 eclevel=H debugcws) rectangularmicroqrcode
+} [110 0 0 0 0 0 0 0 0 0 0 0 0 75 57] debugIsEqual
+
+{
+    % A7 B8
+    (K9K9K9K^000^000^000^000^000^000^000^000) (parse version=R11x59 eclevel=H debugcws) rectangularmicroqrcode
+} [67 184 215 26 227 84 104 0 0 0 0 0 0 0 0] debugIsEqual
+{
+    % B8 A7, inversion of above, previously unencodable B15
+    (^000^000^000^000^000^000^000^000K9K9K9K) (parse version=R11x59 eclevel=H debugcws) rectangularmicroqrcode
+} [104 0 0 0 0 0 0 0 0 67 184 215 26 227 84] debugIsEqual
+
+{
+    % A10 B6
+    (K9K9K9K9K9^000^000^000^000^000^000) (parse version=R11x59 eclevel=H debugcws) rectangularmicroqrcode
+} [69 56 215 26 227 92 107 141 102 0 0 0 0 0 0] debugIsEqual
+    % Inversion of above fails with unencodable B8 A8 (terminal AorN sequence too long to produce B6 A10)
+    (^000^000^000^000^000^000K9K9K9K9K9) (parse version=R11x59 eclevel=H dontdraw) /bwipp.qrcodeNoValidSymbol er_tmpl
+false {
+{
+    % One less fits with B7 A8, though longer msgbits length than B6 A9
+    (^000^000^000^000^000^000K9K9K9K9K) (parse version=R11x59 eclevel=H debugcws) rectangularmicroqrcode
+} [103 0 0 0 0 0 0 75 68 26 147 82 106 77 72] debugIsEqual
+} if
 
 
 % Figures


### PR DESCRIPTION
Partly addresses bwipp-js issue [#237](https://github.com/metafloor/bwip-js/issues/237) by adding `A or N` inclusive sum and in mode 0:

-  moves checking for N mode before checking for A mode and uses new `mode0forceN` array for `N before E` instead of `numN ge 1` check
-  checks `A or N` before B and E instead of just A

and in mode B:

- chooses A for short `A or N` sequences at end that only contain smallish N sequences (restrictions required to avoid other unwanted switches)

Overall the changes should improve some encodations without disimproving others (hopefully).