### PR TITLE
msi: allow any `checktype` containing mod11 if `badmod11` (#17)

### DIFF
--- a/src/msi.ps
+++ b/src/msi.ps
@@ -68,8 +68,8 @@ begin
         /bwipp.msiCheckTypeWithoutCheck (checktype requires includecheck) //raiseerror exec
     } if
 
-    badmod11 checktype (mod11) ne and {
-        /bwipp.msiBadMod11Mismatch (badmod11 requires checktype=mod11) //raiseerror exec
+    badmod11 checktype (mod11) ne checktype (ncrmod11) ne and checktype (mod1110) ne and checktype (ncrmod1110) ne and and {
+        /bwipp.msiBadMod11Mismatch (badmod11 requires checktype with mod11) //raiseerror exec
     } if
 
     checktype (unset) eq { /checktype (mod10) def } if

--- a/tests/ps_tests/msi.ps
+++ b/tests/ps_tests/msi.ps
@@ -1,0 +1,32 @@
+%!PS
+
+% vim: set ts=4 sw=4 et :
+
+/msi dup /uk.co.terryburton.bwipp findresource cvx def
+
+
+% (2211) produces mod-11 '10' check digit
+{ (2211) (dontdraw includecheck checktype=mod11 badmod11) msi /sbs get
+} [2 1 1 2 1 2 2 1 1 2 1 2 1 2 2 1 1 2 1 2 1 2 1 2 2 1 1 2 1 2 1 2 2 1 1 2 1 2 1 2 2 1 1 2 1 2 1 2 1 2 1 2 1] debugIsEqual
+
+{ (2211) (dontdraw includecheck checktype=ncrmod11 badmod11) msi /sbs get
+} [2 1 1 2 1 2 2 1 1 2 1 2 1 2 2 1 1 2 1 2 1 2 1 2 2 1 1 2 1 2 1 2 2 1 1 2 1 2 1 2 2 1 1 2 1 2 1 2 1 2 1 2 1] debugIsEqual
+
+{ (2211) (dontdraw includecheck checktype=mod1110 badmod11) msi /sbs get
+} [2 1 1 2 1 2 2 1 1 2 1 2 1 2 2 1 1 2 1 2 1 2 1 2 2 1 1 2 1 2 1 2 2 1 1 2 1 2 1 2 2 1 1 2 1 2 1 2 1 2 1 2 1 2 1 2 1 2 1 2 1] debugIsEqual
+
+{ (2211) (dontdraw includecheck checktype=ncrmod1110 badmod11) msi /sbs get
+} [2 1 1 2 1 2 2 1 1 2 1 2 1 2 2 1 1 2 1 2 1 2 1 2 2 1 1 2 1 2 1 2 2 1 1 2 1 2 1 2 2 1 1 2 1 2 1 2 1 2 1 2 1 2 1 2 1 2 1 2 1] debugIsEqual
+
+{ (2211) (dontdraw includecheck checktype=mod10 badmod11) msi
+} /bwipp.msiBadMod11Mismatch isError
+
+{ (2211) (dontdraw includecheck checktype=mod1010 badmod11) msi
+} /bwipp.msiBadMod11Mismatch isError
+
+% (1234567) produces different check digit for mod11 and ncrmod11
+{ (1234567) (dontdraw includecheck checktype=mod11) msi /sbs get
+} [2 1 1 2 1 2 1 2 2 1 1 2 1 2 2 1 1 2 1 2 1 2 2 1 2 1 1 2 2 1 1 2 1 2 1 2 2 1 1 2 2 1 1 2 2 1 2 1 1 2 1 2 2 1 2 1 2 1 1 2 2 1 1 2 1 2 1 2 1] debugIsEqual
+
+{ (1234567) (dontdraw includecheck checktype=ncrmod11) msi /sbs get
+} [2 1 1 2 1 2 1 2 2 1 1 2 1 2 2 1 1 2 1 2 1 2 2 1 2 1 1 2 2 1 1 2 1 2 1 2 2 1 1 2 2 1 1 2 2 1 2 1 1 2 1 2 2 1 2 1 2 1 2 1 1 2 1 2 2 1 1 2 1] debugIsEqual

--- a/tests/ps_tests/test.ps
+++ b/tests/ps_tests/test.ps
@@ -93,6 +93,7 @@
     (../../../tests/ps_tests/gs1northamericancoupon.ps)
     (../../../tests/ps_tests/micropdf417.ps)
     (../../../tests/ps_tests/microqrcode.ps)
+    (../../../tests/ps_tests/msi.ps)
     (../../../tests/ps_tests/pdf417.ps)
     (../../../tests/ps_tests/pdf417compact.ps)
     (../../../tests/ps_tests/qrcode.ps)


### PR DESCRIPTION
Re #17 for `msi` allow all `checktype`s containing `mod11` on checking when `badmod11` set (commit [56ac0e5]).