### PR TITLE
msi: Trap mod11 check digit is 10 but `badmod11` not given (#17)

### DIFF
--- a/src/msi.ps
+++ b/src/msi.ps
@@ -112,8 +112,12 @@ begin
         code length 1 sub code {48 sub exch dup 1 sub exch 6 mod 2 add exch} forall pop
         0 code length {3 1 roll mul add} repeat
         11 mod 11 exch sub 11 mod
-        dup 10 eq badmod11 and {
-            pop code length 2 add string dup 0 code putinterval dup code length (10) putinterval
+        dup 10 eq {
+            badmod11 {
+                pop code length 2 add string dup 0 code putinterval dup code length (10) putinterval
+            } {
+                pop /bwipp.msiBadMod11NotSpecified (mod11 check digit is 10 but badmod11 not specified) //raiseerror exec
+            } ifelse
         } {
             code length 1 add string dup 0 code putinterval dup code length 4 -1 roll 48 add put
         } ifelse
@@ -124,8 +128,12 @@ begin
         code length 1 sub code {48 sub exch dup 1 sub exch 8 mod 2 add exch} forall pop
         0 code length {3 1 roll mul add} repeat
         11 mod 11 exch sub 11 mod
-        dup 10 eq badmod11 and {
-            pop code length 2 add string dup 0 code putinterval dup code length (10) putinterval
+        dup 10 eq {
+            badmod11 {
+                pop code length 2 add string dup 0 code putinterval dup code length (10) putinterval
+            } {
+                pop /bwipp.msiBadMod11NotSpecified (mod11 check digit is 10 but badmod11 not specified) //raiseerror exec
+            } ifelse
         } {
             code length 1 add string dup 0 code putinterval dup code length 4 -1 roll 48 add put
         } ifelse

--- a/tests/ps_tests/msi.ps
+++ b/tests/ps_tests/msi.ps
@@ -24,6 +24,9 @@
 { (2211) (dontdraw includecheck checktype=mod1010 badmod11) msi
 } /bwipp.msiBadMod11Mismatch isError
 
+{ (2211) (dontdraw includecheck checktype=mod11) msi
+} /bwipp.msiBadMod11NotSpecified isError
+
 % (1234567) produces different check digit for mod11 and ncrmod11
 { (1234567) (dontdraw includecheck checktype=mod11) msi /sbs get
 } [2 1 1 2 1 2 1 2 2 1 1 2 1 2 2 1 1 2 1 2 1 2 2 1 2 1 1 2 2 1 1 2 1 2 1 2 2 1 1 2 2 1 1 2 2 1 2 1 1 2 1 2 2 1 2 1 2 1 1 2 2 1 1 2 1 2 1 2 1] debugIsEqual


### PR DESCRIPTION
For `msi`, as giving input that results in a mod11 check digit of 10 without specifying `badmod11` causes a PS fail later, trap it ([#17](https://github.com/bwipp/postscriptbarcode/issues/17#issuecomment-1493082368)).