### PR TITLE
daft: Check for empty data (#17)

### DIFF
--- a/src/daft.ps
+++ b/src/daft.ps
@@ -54,6 +54,10 @@ begin
     //processoptions exec /options exch def
     /barcode exch def
 
+    barcode () eq {
+        /bwipp.daftEmptyData (The data must not be empty) //raiseerror exec
+    } if
+
     barcode {
         dup 68 ne exch dup 65 ne exch dup 70 ne exch 84 ne and and and {
             /bwipp.daftBadCharacter (DAFT must contain only characters D, A, F and T) //raiseerror exec

--- a/tests/ps_tests/daft.ps
+++ b/tests/ps_tests/daft.ps
@@ -1,0 +1,47 @@
+%!PS
+
+% vim: set ts=4 sw=4 et :
+
+/daft dup /uk.co.terryburton.bwipp findresource cvx def
+
+/dump_4state_tmpl {
+    /ret exch def
+    /bhs ret /bhs get def
+    /bbs ret /bbs get def
+    [
+        0 1 bbs length 1 sub {
+            /i exch def
+            i 0 ne {0} if
+            bbs i get 0.05 lt { bhs i get 0.14 gt {1} {0} ifelse } { bhs i get 0.09 gt {1} {0} ifelse } ifelse
+        } for
+        0 1 bbs length 1 sub {
+            /i exch def
+            i 0 ne {0} if
+            1
+        } for
+        0 1 bbs length 1 sub {
+            /i exch def
+            i 0 ne {0} if
+            bbs i get 0.05 lt { bhs i get 0.09 gt {1} {0} ifelse } {0} ifelse
+        } for
+    ]
+} def
+
+
+% Input validation
+
+{ () (dontdraw) daft
+} /bwipp.daftEmptyData isError
+
+{ (B) (dontdraw) daft
+} /bwipp.daftBadCharacter isError
+
+
+% Example
+
+(DAFT) (dontdraw) daft dump_4state_tmpl
+[
+    0 0 1 0 1 0 0
+    1 0 1 0 1 0 1
+    1 0 0 0 1 0 0
+] isEqual

--- a/tests/ps_tests/test.ps
+++ b/tests/ps_tests/test.ps
@@ -68,6 +68,7 @@
     (../../../tests/ps_tests/code49.ps)
     (../../../tests/ps_tests/code93ext.ps)
     (../../../tests/ps_tests/codeone.ps)
+    (../../../tests/ps_tests/daft.ps)
     (../../../tests/ps_tests/databarexpanded.ps)
     (../../../tests/ps_tests/databarexpandedcomposite.ps)
     (../../../tests/ps_tests/databarexpandedstacked.ps)


### PR DESCRIPTION
For `daft`, add check that data isn't empty (avoids PS fail) (https://github.com/bwipp/postscriptbarcode/issues/17).