### PR TITLE
code11: Check for empty data (#17)

### DIFF
--- a/src/code11.ps
+++ b/src/code11.ps
@@ -63,6 +63,10 @@ begin
     //processoptions exec /options exch def
     /barcode exch def
 
+    barcode () eq {
+        /bwipp.code11emptyData (The data must not be empty) //raiseerror exec
+    } if
+
     /code11 //loadctx exec
 
     % Create an array containing the character mappings

--- a/tests/ps_tests/code11.ps
+++ b/tests/ps_tests/code11.ps
@@ -1,0 +1,41 @@
+%!PS
+
+% vim: set ts=4 sw=4 et :
+
+/code11 dup /uk.co.terryburton.bwipp findresource cvx def
+
+
+% Input validation
+
+{ () (dontdraw) code11
+} /bwipp.code11emptyData isError
+
+{ () (dontdraw validatecheck) code11
+} /bwipp.code11emptyData isError
+
+{ (A) (dontdraw) code11
+} /bwipp.code11badCharacter isError
+
+{ (12345678901) (dontdraw validatecheck) code11
+} /bwipp.code11badLength isError
+
+{ (123-454) (dontdraw validatecheck) code11  % Check digit should be '5'
+} /bwipp.code11badCheckDigit isError
+
+{ (1234567890149) (dontdraw validatecheck) code11  % 2nd check digit should be '-'
+} /bwipp.code11badCheckDigits isError
+
+
+% Examples
+
+{ (0) (dontdraw) code11 /sbs get
+} [ 1 1 3 3 1 1 1 1 1 1 3 1 1 1 3 3 1 1 ] debugIsEqual
+
+{ (0) (dontdraw validatecheck) code11 /sbs get  % Degenerate case with check digit only still allowed
+} [ 1 1 3 3 1 1 1 1 1 1 3 1 1 1 3 3 1 1 ] debugIsEqual
+
+{ (123-455) (dontdraw validatecheck) code11 /sbs get
+} [ 1 1 3 3 1 1 3 1 1 1 3 1 1 3 1 1 3 1 3 3 1 1 1 1 1 1 3 1 1 1 1 1 3 1 3 1 3 1 3 1 1 1 3 1 3 1 1 1 1 1 3 3 1 1 ] debugIsEqual
+
+{ (123456789014-) (dontdraw validatecheck) code11 /sbs get
+} [ 1 1 3 3 1 1 3 1 1 1 3 1 1 3 1 1 3 1 3 3 1 1 1 1 1 1 3 1 3 1 3 1 3 1 1 1 1 3 3 1 1 1 1 1 1 3 3 1 3 1 1 3 1 1 3 1 1 1 1 1 1 1 1 1 3 1 3 1 1 1 3 1 1 1 3 1 3 1 1 1 3 1 1 1 1 1 3 3 1 1 ] debugIsEqual

--- a/tests/ps_tests/test.ps
+++ b/tests/ps_tests/test.ps
@@ -63,6 +63,7 @@
     (../../../tests/ps_tests/azteccode.ps)
     (../../../tests/ps_tests/bc412.ps)
     (../../../tests/ps_tests/codablockf.ps)
+    (../../../tests/ps_tests/code11.ps)
     (../../../tests/ps_tests/code128.ps)
     (../../../tests/ps_tests/code16k.ps)
     (../../../tests/ps_tests/code49.ps)


### PR DESCRIPTION
For `code11`, add check that data isn't empty (avoids PS fail when `validatecheck` given) (https://github.com/bwipp/postscriptbarcode/issues/17).