### PR TITLE
code39(/code39ext): Check for empty data (#17)

### DIFF
--- a/src/code39.ps
+++ b/src/code39.ps
@@ -64,6 +64,10 @@ begin
     //processoptions exec /options exch def
     /barcode exch def
 
+    barcode () eq {
+        /bwipp.code39emptyData (The data must not be empty) //raiseerror exec
+    } if
+
     /code39 //loadctx exec
 
 {

--- a/tests/ps_tests/code39.ps
+++ b/tests/ps_tests/code39.ps
@@ -1,0 +1,50 @@
+%!PS
+
+% ISO/IEC 16388:2007
+
+% vim: set ts=4 sw=4 et :
+
+/code39 dup /uk.co.terryburton.bwipp findresource cvx def
+/code39ext dup /uk.co.terryburton.bwipp findresource cvx def
+
+
+% Input validation
+
+{ () (dontdraw) code39
+} /bwipp.code39emptyData isError
+{ () (dontdraw) code39ext
+} /bwipp.code39emptyData isError
+
+{ () (dontdraw validatecheck) code39
+} /bwipp.code39emptyData isError
+{ () (dontdraw validatecheck) code39ext
+} /bwipp.code39emptyData isError
+
+{ (,) (dontdraw) code39
+} /bwipp.code39badCharacter isError
+
+{ (^161) (dontdraw parse) code39ext
+} /bwipp.code39extBadCharacter isError
+
+{ (Z1.) (dontdraw validatecheck) code39  % Check digit should be '-'
+} /bwipp.code39badCheckDigit isError
+{ (Z1.) (dontdraw validatecheck) code39ext
+} /bwipp.code39badCheckDigit isError
+
+
+% Examples
+
+{ (0) (dontdraw) code39 /sbs get
+} [ 1 3 1 1 3 1 3 1 1 1 1 1 1 3 3 1 3 1 1 1 1 3 1 1 3 1 3 1 1 1 ] debugIsEqual
+
+{ (0) (dontdraw validatecheck) code39 /sbs get  % Degenerate case with check digit only still allowed
+} [ 1 3 1 1 3 1 3 1 1 1 1 1 1 3 3 1 3 1 1 1 1 3 1 1 3 1 3 1 1 1 ] debugIsEqual
+
+{ (1A) (dontdraw) code39 /sbs get  % Figure 1, same
+} [ 1 3 1 1 3 1 3 1 1 1 3 1 1 3 1 1 1 1 3 1 3 1 1 1 1 3 1 1 3 1 1 3 1 1 3 1 3 1 1 1 ] debugIsEqual
+
+{ (Z1-) (dontdraw validatecheck) code39 /sbs get
+} [ 1 3 1 1 3 1 3 1 1 1 1 3 3 1 3 1 1 1 1 1 3 1 1 3 1 1 1 1 3 1 1 3 1 1 1 1 3 1 3 1 1 3 1 1 3 1 3 1 1 1 ] debugIsEqual
+
+{ (,I) (dontdraw validatecheck) code39ext /sbs get
+} [ 1 3 1 1 3 1 3 1 1 1 1 3 1 3 1 1 1 3 1 1 1 1 3 1 1 1 1 3 3 1 1 1 3 1 1 3 3 1 1 1 1 3 1 1 3 1 3 1 1 1 ] debugIsEqual

--- a/tests/ps_tests/test.ps
+++ b/tests/ps_tests/test.ps
@@ -66,6 +66,7 @@
     (../../../tests/ps_tests/code11.ps)
     (../../../tests/ps_tests/code128.ps)
     (../../../tests/ps_tests/code16k.ps)
+    (../../../tests/ps_tests/code39.ps)
     (../../../tests/ps_tests/code49.ps)
     (../../../tests/ps_tests/code93ext.ps)
     (../../../tests/ps_tests/codeone.ps)


### PR DESCRIPTION
For `code39` (and `code39ext`), add check that data isn't empty (avoids PS fail when `validatecheck` given) (https://github.com/bwipp/postscriptbarcode/issues/17).