### PR TITLE
code2of5(/industrial/iata/matrix/coop/datalogic): Check for empty data (#17)

### DIFF
--- a/src/code2of5.ps
+++ b/src/code2of5.ps
@@ -64,6 +64,10 @@ begin
     //processoptions exec /options exch def
     /barcode exch def
 
+    barcode () eq {
+        /bwipp.code2of5emptyData (The data must not be empty) //raiseerror exec
+    } if
+
     /code2of5 //loadctx exec
 
     % Validate input

--- a/tests/ps_tests/code2of5.ps
+++ b/tests/ps_tests/code2of5.ps
@@ -1,0 +1,68 @@
+%!PS
+
+% vim: set ts=4 sw=4 et :
+
+/code2of5 dup /uk.co.terryburton.bwipp findresource cvx def
+/industrial2of5 dup /uk.co.terryburton.bwipp findresource cvx def
+/iata2of5 dup /uk.co.terryburton.bwipp findresource cvx def
+/matrix2of5 dup /uk.co.terryburton.bwipp findresource cvx def
+/coop2of5 dup /uk.co.terryburton.bwipp findresource cvx def
+/datalogic2of5 dup /uk.co.terryburton.bwipp findresource cvx def
+
+
+% Input validation
+
+{ () (dontdraw) code2of5
+} /bwipp.code2of5emptyData isError
+{ () (dontdraw) industrial2of5
+} /bwipp.code2of5emptyData isError
+{ () (dontdraw) iata2of5
+} /bwipp.code2of5emptyData isError
+{ () (dontdraw) matrix2of5
+} /bwipp.code2of5emptyData isError
+{ () (dontdraw) coop2of5
+} /bwipp.code2of5emptyData isError
+{ () (dontdraw) datalogic2of5
+} /bwipp.code2of5emptyData isError
+
+{ () (dontdraw validatecheck) code2of5
+} /bwipp.code2of5emptyData isError
+
+{ (A) (dontdraw) code2of5
+} /bwipp.code2of5badCharacter isError
+
+{ (876543211) (dontdraw validatecheck) code2of5  % Check digit should be '2'
+} /bwipp.code2of5badCheckDigit isError
+
+{ (0) (dontdraw version=blah) code2of5
+} /bwipp.code2of5badVersion isError
+
+
+% Examples
+
+{ (0) (dontdraw) code2of5 /sbs get
+} [ 3 1 3 1 1 1 1 1 1 1 3 1 3 1 1 1 3 1 1 1 3 ] debugIsEqual
+
+{ (0) (dontdraw validatecheck) code2of5 /sbs get  % Degenerate case with check digit only still allowed
+} [ 3 1 3 1 1 1 1 1 1 1 3 1 3 1 1 1 3 1 1 1 3 ] debugIsEqual
+
+{ (876543212) (dontdraw validatecheck) code2of5 /sbs get
+} [ 3 1 3 1 1 1 3 1 1 1 1 1 3 1 1 1 1 1 1 1 1 1 3 1 3 1 1 1 3 1 3 1 1 1 1 1 3 1 1 1 3 1 1 1 1 1 1 1 1 1 3 1 1 1 3 1 3 1 3 1 1 1 1 1 1 1 1 1 3 1 1 1 1 1 3 1 3 1 1 1 1 1 1 1 3 1 1 1 3 1 1 1 1 1 3 1 3 1 1 1 3 ] debugIsEqual
+
+{ (87654321) (dontdraw) code2of5 /sbs get
+} [ 3 1 3 1 1 1 3 1 1 1 1 1 3 1 1 1 1 1 1 1 1 1 3 1 3 1 1 1 3 1 3 1 1 1 1 1 3 1 1 1 3 1 1 1 1 1 1 1 1 1 3 1 1 1 3 1 3 1 3 1 1 1 1 1 1 1 1 1 3 1 1 1 1 1 3 1 3 1 1 1 1 1 1 1 3 1 3 1 1 1 3 ] debugIsEqual
+
+{ (87654321) (dontdraw) industrial2of5 /sbs get  % Same as default
+} [ 3 1 3 1 1 1 3 1 1 1 1 1 3 1 1 1 1 1 1 1 1 1 3 1 3 1 1 1 3 1 3 1 1 1 1 1 3 1 1 1 3 1 1 1 1 1 1 1 1 1 3 1 1 1 3 1 3 1 3 1 1 1 1 1 1 1 1 1 3 1 1 1 1 1 3 1 3 1 1 1 1 1 1 1 3 1 3 1 1 1 3 ] debugIsEqual
+
+{ (87654321) (dontdraw) iata2of5 /sbs get
+} [ 1 1 1 1 3 1 1 1 1 1 3 1 1 1 1 1 1 1 1 1 3 1 3 1 1 1 3 1 3 1 1 1 1 1 3 1 1 1 3 1 1 1 1 1 1 1 1 1 3 1 1 1 3 1 3 1 3 1 1 1 1 1 1 1 1 1 3 1 1 1 1 1 3 1 3 1 1 1 1 1 1 1 3 1 3 1 1 ] debugIsEqual
+
+{ (87654321) (dontdraw) matrix2of5 /sbs get
+} [ 3 1 1 1 1 1 3 1 1 3 1 1 1 1 1 3 3 1 1 3 3 1 1 1 3 1 3 1 1 1 1 1 3 1 3 1 3 3 1 1 1 1 1 3 1 1 3 1 3 1 1 1 3 1 3 1 1 1 1 ] debugIsEqual
+
+{ (87654321) (dontdraw) coop2of5 /sbs get
+} [ 3 1 3 1 3 1 1 3 1 1 3 1 1 1 3 1 1 3 3 1 1 1 1 3 1 3 1 1 1 3 1 1 3 1 1 1 3 3 1 1 1 1 3 1 3 1 1 1 1 3 3 1 1 3 3 ] debugIsEqual
+
+{ (87654321) (dontdraw) datalogic2of5 /sbs get
+} [ 1 1 1 1 3 1 1 3 1 1 1 1 1 3 3 1 1 3 3 1 1 1 3 1 3 1 1 1 1 1 3 1 3 1 3 3 1 1 1 1 1 3 1 1 3 1 3 1 1 1 3 1 3 1 1 ] debugIsEqual

--- a/tests/ps_tests/test.ps
+++ b/tests/ps_tests/test.ps
@@ -66,6 +66,7 @@
     (../../../tests/ps_tests/code11.ps)
     (../../../tests/ps_tests/code128.ps)
     (../../../tests/ps_tests/code16k.ps)
+    (../../../tests/ps_tests/code2of5.ps)
     (../../../tests/ps_tests/code39.ps)
     (../../../tests/ps_tests/code49.ps)
     (../../../tests/ps_tests/code93ext.ps)


### PR DESCRIPTION
For `code2of5` (and `industrial2of5`, `iata2of5`, `matrix2of5`, `coop2of5`, `datalogic2of5`), add check that data isn't empty (avoids PS fail when `validatecheck` given) (https://github.com/bwipp/postscriptbarcode/issues/17).