### PR TITLE
databarlimited: Move length check before BadAI check to avoid PS fail (#17)

### DIFF
--- a/src/databarlimited.ps
+++ b/src/databarlimited.ps
@@ -60,11 +60,11 @@ begin
     /databarlimited //loadctx exec
 
     % Validate the input
-    barcode 0 4 getinterval (\(01\)) ne {
-        /bwipp.databarlimitedBadAI (GS1 DataBar Limited must begin with (01) application identifier) //raiseerror exec
-    } if
     barcode length 17 ne barcode length 18 ne and {
         /bwipp.databarlimitedBadLength (GS1 DataBar Limited must be 13 or 14 digits) //raiseerror exec
+    } if
+    barcode 0 4 getinterval (\(01\)) ne {
+        /bwipp.databarlimitedBadAI (GS1 DataBar Limited must begin with (01) application identifier) //raiseerror exec
     } if
     barcode 4 get dup 48 lt exch 49 gt or {
         /bwipp.databarlimitedBadStartDigit (GS1 DataBar Limited must begin with 0 or 1) //raiseerror exec

--- a/tests/ps_tests/databarlimited.ps
+++ b/tests/ps_tests/databarlimited.ps
@@ -27,6 +27,7 @@
 
 
 ((01)15012345678908)    /bwipp.databarlimitedBadCheckDigit  er_tmpl
+()                      /bwipp.databarlimitedBadLength      er_tmpl
 ((01)150123456789071)   /bwipp.databarlimitedBadLength      er_tmpl
 ((01)150123456789)      /bwipp.databarlimitedBadLength      er_tmpl
 ((01)25012345678907)    /bwipp.databarlimitedBadStartDigit  er_tmpl


### PR DESCRIPTION
For `databarlimited`, move length check to before BadAI check to avoid PS fail on BadAI `getinterval` (#17)