### PR TITLE
databaromni/stacked/truncated: Move length check before BadAI check (#17)

### DIFF
--- a/src/databaromni.ps
+++ b/src/databaromni.ps
@@ -60,11 +60,11 @@ begin
     //processoptions exec /options exch def
     /barcode exch def
 
-    barcode 0 4 getinterval (\(01\)) ne {
-        /bwipp.databaromniBadAI (GS1 DataBar Omnidirectional must begin with (01) application identifier) //raiseerror exec
-    } if
     barcode length 17 ne barcode length 18 ne and {
         /bwipp.databaromniBadLength (GS1 DataBar Omnidirectional must be 13 or 14 digits) //raiseerror exec
+    } if
+    barcode 0 4 getinterval (\(01\)) ne {
+        /bwipp.databaromniBadAI (GS1 DataBar Omnidirectional must begin with (01) application identifier) //raiseerror exec
     } if
     barcode 4 barcode length 4 sub getinterval {
         dup 48 lt exch 57 gt or {

--- a/src/databarstacked.ps
+++ b/src/databarstacked.ps
@@ -55,11 +55,11 @@ begin
     /barcode exch def
 
     % Validate the input
-    barcode 0 4 getinterval (\(01\)) ne {
-        /bwipp.databarstackedBadAI (GS1 DataBar Stacked must begin with (01) application identifier) //raiseerror exec
-    } if
     barcode length 17 ne barcode length 18 ne and {
         /bwipp.databarstackedBadLength (GS1 DataBar Stacked must be 13 or 14 digits) //raiseerror exec
+    } if
+    barcode 0 4 getinterval (\(01\)) ne {
+        /bwipp.databarstackedBadAI (GS1 DataBar Stacked must begin with (01) application identifier) //raiseerror exec
     } if
     barcode 4 barcode length 4 sub getinterval {
         dup 48 lt exch 57 gt or {

--- a/src/databartruncated.ps
+++ b/src/databartruncated.ps
@@ -55,11 +55,11 @@ begin
     /barcode exch def
 
     % Validate the input
-    barcode 0 4 getinterval (\(01\)) ne {
-        /bwipp.databartruncatedBadAI (GS1 DataBar Truncated must begin with (01) application identifier) //raiseerror exec
-    } if
     barcode length 17 ne barcode length 18 ne and {
         /bwipp.databartruncatedBadLength (GS1 DataBar Truncated must be 13 or 14 digits) //raiseerror exec
+    } if
+    barcode 0 4 getinterval (\(01\)) ne {
+        /bwipp.databartruncatedBadAI (GS1 DataBar Truncated must begin with (01) application identifier) //raiseerror exec
     } if
     barcode 4 barcode length 4 sub getinterval {
         dup 48 lt exch 57 gt or {

--- a/tests/ps_tests/databaromni.ps
+++ b/tests/ps_tests/databaromni.ps
@@ -27,6 +27,7 @@
 
 
 ((01)20012345678908)    /bwipp.databaromniBadCheckDigit  er_tmpl
+()                      /bwipp.databaromniBadLength      er_tmpl
 ((01)200123456789091)   /bwipp.databaromniBadLength      er_tmpl
 ((01)200123456789)      /bwipp.databaromniBadLength      er_tmpl
 ((01)2001234567890A)    /bwipp.databaromniBadCharacter   er_tmpl

--- a/tests/ps_tests/databarstacked.ps
+++ b/tests/ps_tests/databarstacked.ps
@@ -36,6 +36,7 @@
 
 
 ((01)20012345678908)    /bwipp.databarstackedBadCheckDigit  er_tmpl  % Should be '9'
+()                      /bwipp.databarstackedBadLength      er_tmpl
 ((01)200123456789091)   /bwipp.databarstackedBadLength      er_tmpl
 ((01)200123456789)      /bwipp.databarstackedBadLength      er_tmpl
 ((01)2001234567890A)    /bwipp.databarstackedBadCharacter   er_tmpl

--- a/tests/ps_tests/databartruncated.ps
+++ b/tests/ps_tests/databartruncated.ps
@@ -22,6 +22,7 @@
     eq_tmpl
 
 ((01)00012345678906)    /bwipp.databartruncatedBadCheckDigit    er_tmpl
+()                      /bwipp.databartruncatedBadLength        er_tmpl
 ((01)000123456789051)   /bwipp.databartruncatedBadLength        er_tmpl
 ((01)000123456789)      /bwipp.databartruncatedBadLength        er_tmpl
 ((01)0001234567890A)    /bwipp.databartruncatedBadCharacter     er_tmpl


### PR DESCRIPTION
For `databaromni`, `databarstacked` and `databartruncated`, move length check before BadAI check to avoid PS fail on BadAI `getinterval` (#17)