### PR TITLE
ean14: Move length check before BadAI check (#17)

### DIFF
--- a/src/ean14.ps
+++ b/src/ean14.ps
@@ -68,11 +68,11 @@ begin
     /hasspace text length barcode length ne def
 
     % Validate the input
-    barcode 0 4 getinterval (\(01\)) ne {
-        /bwipp.ean14badAI (GS1-14 must begin with (01) application identifier) //raiseerror exec
-    } if
     barcode length 17 ne barcode length 18 ne and {
         /bwipp.ean14badLength (GS1-14 must be 13 or 14 digits) //raiseerror exec
+    } if
+    barcode 0 4 getinterval (\(01\)) ne {
+        /bwipp.ean14badAI (GS1-14 must begin with (01) application identifier) //raiseerror exec
     } if
     barcode 4 barcode length 4 sub getinterval {
         dup 48 lt exch 57 gt or {

--- a/tests/ps_tests/ean14.ps
+++ b/tests/ps_tests/ean14.ps
@@ -1,0 +1,28 @@
+%!PS
+
+% vim: set ts=4 sw=4 et :
+
+/ean14 dup /uk.co.terryburton.bwipp findresource cvx def
+
+/eq_tmpl {
+    exch { 0 (dontdraw) ean14 /sbs get } dup 3 -1 roll 0 exch put
+    exch isEqual
+} def
+
+/er_tmpl {
+    exch { 0 (dontdraw) ean14 /sbs get } dup 3 -1 roll 0 exch put
+    exch isError
+} def
+
+
+((01)09528765432108)
+    [2 1 1 2 3 2 4 1 1 1 3 1 2 2 2 1 2 2 2 2 1 2 1 3 2 1 3 3 1 1 4 2 1 1 1 2 1 2 1 1 2 4 1 1 2 3 3 1 2 1 3 2 1 2 1 3 2 2 1 2 3 3 2 1 1 1 2 3 3 1 1 1 2]
+    eq_tmpl
+
+
+((01)09528765432107)    /bwipp.ean14badCheckDigit  er_tmpl
+()                      /bwipp.ean14badLength      er_tmpl
+((01)095287654321081)   /bwipp.ean14badLength      er_tmpl
+((01)095287654321)      /bwipp.ean14badLength      er_tmpl
+((01)0952876543210A)    /bwipp.ean14badCharacter   er_tmpl
+((02)0952876543210)     /bwipp.ean14badAI          er_tmpl

--- a/tests/ps_tests/test.ps
+++ b/tests/ps_tests/test.ps
@@ -90,6 +90,7 @@
     (../../../tests/ps_tests/dotcode.ps)
     (../../../tests/ps_tests/ean13.ps)
     (../../../tests/ps_tests/ean13composite.ps)
+    (../../../tests/ps_tests/ean14.ps)
     (../../../tests/ps_tests/ean8.ps)
     (../../../tests/ps_tests/ean8composite.ps)
     (../../../tests/ps_tests/gs1-128.ps)


### PR DESCRIPTION
For `ean14`, move length check before BadAI check to avoid PS fail on BadAI `getinterval` (#17)