### PR TITLE
gs1-cc: Set `cccolumns` when `lintype` not set to avoid PS fail (#17)

### DIFF
--- a/src/gs1-cc.ps
+++ b/src/gs1-cc.ps
@@ -106,7 +106,7 @@ begin
             } if
             linwidth 52 sub 17 idiv
         } {
-            lintypecccolumns lintype get
+            lintype () ne { lintypecccolumns lintype get } {2} ifelse
         } ifelse
         /cccolumns exch def
     } if

--- a/tests/ps_tests/gs1-cc.ps
+++ b/tests/ps_tests/gs1-cc.ps
@@ -29,3 +29,11 @@
     % Medium composite width, largeish linear width, rows 1 -> 3, cols 31 -> 30
     ((20)12(90)12345678901234567890) (ccversion=c lintype=gs1-128 linwidth=585 debugcws dontlint) gs1-cc
 } [82 920 901 50 504 633 638 559 197 44 694 740 448 55 320 705 870 633 13 755 176 442 608 110 641 511 841 366 27 610 352 885 316 221 383 123 782 732 55 320 705 870 633 13 755 176 442 608 110 641 511 841 366 27 610 352 885 316 221 383 123 782 732 55 320 705 870 633 13 755 176 442 608 110 641 511 841 366 16 132 33 8 843 864 255 772 741 55 845 682] debugIsEqual
+
+
+{ ()      ()             gs1-cc }                /bwipp.GS1aiMissingOpenParen isError
+{ ()      (lintype=upca) gs1-cc }                /bwipp.GS1aiMissingOpenParen isError
+{ ((90)1) (ccversion=d)  gs1-cc }                /bwipp.gs1ccBadCCversion     isError
+{ ((90)1) (cccolumns=31) gs1-cc }                /bwipp.gs1ccColumnsTooBig    isError
+{ ((90)1) (lintype=blah) gs1-cc }                /bwipp.gs1ccBadLinType       isError
+{ ((90)1) (lintype=gs1-128 ccversion=c) gs1-cc } /bwipp.gs1ccMissingLinWidth  isError


### PR DESCRIPTION
For `gs1-cc`, set `cccolumns` to arbitrary value (2) when `lintype` not set to avoid PS fail on `lintypecccolumns` lookup (#17)