### PR TITLE
bc412: Check for empty data to avoid PS fail (#17)

### DIFF
--- a/src/bc412.ps
+++ b/src/bc412.ps
@@ -65,6 +65,10 @@ begin
     //processoptions exec /options exch def
     /barcode exch def
 
+    barcode () eq {
+        /bwipp.bc412emptyData (The data must not be empty) //raiseerror exec
+    } if
+
     semi {
         % Implies includecheck and includecheckintext also
         /includestartstop true def

--- a/tests/ps_tests/bc412.ps
+++ b/tests/ps_tests/bc412.ps
@@ -68,6 +68,11 @@
     /bwipp.bc412badCheckDigit
     er_tmpl_validate
 
+() /bwipp.bc412emptyData er_tmpl
+() /bwipp.bc412emptyData er_tmpl_validate
+() /bwipp.bc412emptyData er_tmpl_semi
+() /bwipp.bc412emptyData er_tmpl_semi_validate
+
 (1234567890ABCDEFGH)  % 18 max len
     [1 2 1 1 1 1 1 2 1 4 1 2 1 1 1 4 1 1 1 1 1 1 1 3 1 3 1 1 1 1 1 4 1 2 1 1 1 1 1 5 1 1 1 1 1 2 1 1 1 4 1 1 1 2 1 2 1 3 1 1 1 2 1 3 1 2 1 1 1 2 1 4 1 1 1 1 1 3 1 1 1 3 1 1 1 1 1 1 1 5 1 1 1 3 1 2 1 2 1 1 1 3 1 3 1 1 1 1 1 4 1 1 1 2 1 1 1 4 1 2 1 1 1 1 1 5 1 1 1 1 1 2 1 1 1 1 1 4 1 2 1 1 1 2 1 3 1 2 1 1 1 3 1 2 1 1 1]
     eq_tmpl_semi


### PR DESCRIPTION
For `bc412`, add check that data isn't empty (avoids PS fail when `validatecheck` given and not semi) (#17).