### PR TITLE
plessey: Check for empty data to avoid PS fail when `validatecheck` given (#17)

### DIFF
--- a/src/plessey.ps
+++ b/src/plessey.ps
@@ -63,6 +63,10 @@ begin
     //processoptions exec /options exch def
     /barcode exch def
 
+    barcode () eq {
+        /bwipp.plesseyEmptyData (The data must not be empty) //raiseerror exec
+    } if
+
     /plessey //loadctx exec
 
     % Create a string of the available characters

--- a/tests/ps_tests/plessey.ps
+++ b/tests/ps_tests/plessey.ps
@@ -1,0 +1,39 @@
+%!PS
+
+% vim: set ts=4 sw=4 et :
+
+/plessey dup /uk.co.terryburton.bwipp findresource cvx def
+
+
+% Input validation
+
+{ () (dontdraw) plessey
+} /bwipp.plesseyEmptyData isError
+
+{ () (dontdraw validatecheck) plessey
+} /bwipp.plesseyEmptyData isError
+
+{ (G) (dontdraw) plessey
+} /bwipp.plesseyBadCharacter isError
+
+{ (1234ABCDEFDF) (dontdraw validatecheck) plessey  % Check digits should be "CF"
+} /bwipp.plesseyBadCheckDigits isError
+
+{ (1234ABCDEFCE) (dontdraw validatecheck) plessey
+} /bwipp.plesseyBadCheckDigits isError
+
+{ (01) (dontdraw validatecheck) plessey  % Check digits should be "00"
+} /bwipp.plesseyBadCheckDigits isError
+
+
+% Examples
+
+(1234ABCDEFCF) (dontdraw validatecheck) plessey /sbs get
+[
+    3 2 3 2 1 4 3 2 3 2 1 4 1 4 1 4 1 4 3 2 1 4 1 4 3 2 3 2 1 4 1 4 1 4 1 4 3 2 1 4 1 4 3 2 1 4 3 2 3 2 3 2 1 4 3 2 1 4 1 4 3 2 3 2 3 2 1 4 3 2 3 2 1 4 3 2 3 2 3 2 3 2 3 2 3 2 3 2 1 4 1 4 3 2 3 2 3 2 3 2 3 2 3 2 5 4 1 4 1 2 3 2 3
+] debugIsEqual
+
+(00) (dontdraw validatecheck) plessey /sbs get  % Degenerate case with check digits only still allowed
+[
+    3 2 3 2 1 4 3 2 1 4 1 4 1 4 1 4 1 4 1 4 1 4 1 4 5 4 1 4 1 2 3 2 3
+] debugIsEqual

--- a/tests/ps_tests/test.ps
+++ b/tests/ps_tests/test.ps
@@ -112,6 +112,7 @@
     (../../../tests/ps_tests/micropdf417.ps)
     (../../../tests/ps_tests/microqrcode.ps)
     (../../../tests/ps_tests/msi.ps)
+    (../../../tests/ps_tests/plessey.ps)
     (../../../tests/ps_tests/pdf417.ps)
     (../../../tests/ps_tests/pdf417compact.ps)
     (../../../tests/ps_tests/qrcode.ps)


### PR DESCRIPTION
For `plessey`,  add check that data isn't empty (avoids PS fail when `validatecheck` given) (#17).