### PR TITLE
posicode: Add checks for version and for input data if limited to avoid PS fails (#17)

### DIFF
--- a/src/posicode.ps
+++ b/src/posicode.ps
@@ -113,6 +113,10 @@ begin
     ] def
 } ctxdef
 
+    version (a) ne version (b) ne and version (limiteda) ne and version (limitedb) ne and {
+        /bwipp.posicodeInvalidVersion (The version must be either a, b, limiteda or limitedb) //raiseerror exec
+    } if
+
     /charmaps version (a) eq version (b) eq or {charmapsnormal} {chapmapslimited} ifelse def
 
     % Invert charmaps to give character to value maps for each state
@@ -131,6 +135,15 @@ begin
     /set0 charvals 0 get def
     /set1 charvals 1 get def
     /set2 charvals 2 get def
+
+    % Validate the input if limited
+    version (limiteda) eq version (limitedb) eq or {
+        0 1 barcode length 1 sub {
+            barcode exch 1 getinterval 0 get set0 exch known not {
+                /bwipp.posicodeBadCharacter (Posicode limited must contain only digits, capital letters, and the symbols - and .) //raiseerror exec
+            } if
+        } for
+    } if
 
     raw {/encoding (raw) def} if
 

--- a/tests/ps_tests/posicode.ps
+++ b/tests/ps_tests/posicode.ps
@@ -1,0 +1,35 @@
+%!PS
+
+% vim: set ts=4 sw=4 et :
+
+/posicode dup /uk.co.terryburton.bwipp findresource cvx def
+
+
+% Input validation
+
+{ (ABC123) (dontdraw version=c) posicode
+} /bwipp.posicodeInvalidVersion isError
+
+{ (a) (dontdraw version=limitedb) posicode
+} /bwipp.posicodeBadCharacter isError
+
+{ (AB^029CD) (dontdraw parse version=limitedb) posicode
+} /bwipp.posicodeBadCharacter isError
+
+
+% Examples
+
+(AB^029CD) (dontdraw parse version=a) posicode /sbs get
+[
+    1 12 1 1 1 1 1 2 1 8 1 1 1 1 1 7 1 2 1 1 1 1 1 1 1 8 1 1 1 4 1 2 1 6 1 3 1 1 1 5 1 4 1 1 1 1 1 2 1 6 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 11 1
+] debugIsEqual
+
+(AB^029CD) (dontdraw parse version=b) posicode /sbs get
+[
+    1 12 1 2 1 3 1 2 1 9 1 2 1 2 1 8 1 3 1 2 1 2 1 2 1 9 1 2 1 5 1 3 1 7 1 4 1 2 1 6 1 5 1 2 1 2 1 3 1 7 1 4 1 2 1 2 1 2 1 2 1 2 1 2 1 12 1
+] debugIsEqual
+
+(1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ-.) (dontdraw version=limiteda) posicode /sbs get
+[
+    1 5 1 1 1 1 1 1 1 3 1 2 1 1 1 2 1 3 1 1 1 1 1 4 1 2 1 3 1 1 1 2 1 2 1 2 1 2 1 1 1 3 1 4 1 1 1 1 1 3 1 2 1 1 1 3 1 1 1 2 1 1 1 4 1 1 1 7 1 1 1 1 1 6 1 2 1 1 1 5 1 3 1 1 1 4 1 4 1 1 1 3 1 5 1 1 1 2 1 6 1 1 1 1 1 7 1 1 1 6 1 1 1 2 1 5 1 2 1 2 1 4 1 3 1 2 1 3 1 4 1 2 1 2 1 5 1 2 1 1 1 6 1 2 1 5 1 1 1 3 1 4 1 2 1 3 1 3 1 3 1 3 1 2 1 4 1 3 1 1 1 5 1 3 1 4 1 1 1 4 1 3 1 2 1 4 1 2 1 3 1 4 1 1 1 4 1 4 1 3 1 1 1 5 1 2 1 2 1 5 1 1 1 3 1 5 1 2 1 1 1 6 1 1 1 2 1 6 1 1 1 1 1 7 1 1 1 7 1 1 1 1 1 3 1 1 1
+] debugIsEqual

--- a/tests/ps_tests/test.ps
+++ b/tests/ps_tests/test.ps
@@ -115,6 +115,7 @@
     (../../../tests/ps_tests/plessey.ps)
     (../../../tests/ps_tests/pdf417.ps)
     (../../../tests/ps_tests/pdf417compact.ps)
+    (../../../tests/ps_tests/posicode.ps)
     (../../../tests/ps_tests/qrcode.ps)
     (../../../tests/ps_tests/rectangularmicroqrcode.ps)
     (../../../tests/ps_tests/royalmail.ps)


### PR DESCRIPTION
For `posicode`, add checks for version and for input data if limited to avoid various PS fails (#17).