### PR TITLE
rationalizedCodabar: Add length check to avoid PS fail (#17)

### DIFF
--- a/src/rationalizedCodabar.ps
+++ b/src/rationalizedCodabar.ps
@@ -64,6 +64,10 @@ begin
     //processoptions exec /options exch def
     /barcode exch def
 
+    barcode length 2 lt barcode length 3 lt validatecheck and or {
+        /bwipp.rationalizedCodabarBadLength (Codabar must be at least 2 characters in length excluding any check digit) //raiseerror exec
+    } if
+
     /rationalizedCodabar //loadctx exec
 
 {

--- a/tests/ps_tests/rationalizedCodabar.ps
+++ b/tests/ps_tests/rationalizedCodabar.ps
@@ -1,0 +1,51 @@
+%!PS
+
+% BS EN 798:1996
+
+% vim: set ts=4 sw=4 et :
+
+/rationalizedCodabar dup /uk.co.terryburton.bwipp findresource cvx def
+
+
+% Input validation
+
+{ (A) (dontdraw) rationalizedCodabar
+} /bwipp.rationalizedCodabarBadLength isError
+
+{ (AB) (dontdraw validatecheck) rationalizedCodabar
+} /bwipp.rationalizedCodabarBadLength isError
+
+{ (TB) (dontdraw) rationalizedCodabar
+} /bwipp.rationalizedCodabarBadStartStop isError
+
+{ (AN) (dontdraw altstartstop) rationalizedCodabar
+} /bwipp.rationalizedCodabarBadAltStartStop isError
+
+{ (AAB) (dontdraw) rationalizedCodabar
+} /bwipp.rationalizedCodabarBadCharacter isError
+
+{ (A37859.B) (dontdraw validatecheck) rationalizedCodabar  % Check digit should be "+"
+} /bwipp.rationalizedCodabarBadCheckDigit isError
+
+
+% Examples
+
+(A37859B) (dontdraw) rationalizedCodabar /sbs get  % Figure 1, same
+[
+    1 1 3 3 1 3 1 1 3 3 1 1 1 1 1 1 1 3 1 1 3 1 1 1 1 3 3 1 1 1 1 1 3 1 1 1 1 3 1 1 3 1 1 3 1 1 1 1 1 3 1 3 1 1 3 1
+] debugIsEqual
+
+(A37859+B) (dontdraw validatecheck) rationalizedCodabar /sbs get
+[
+    1 1 3 3 1 3 1 1 3 3 1 1 1 1 1 1 1 3 1 1 3 1 1 1 1 3 3 1 1 1 1 1 3 1 1 1 1 3 1 1 3 1 1 3 1 1 1 1 1 1 3 1 3 1 3 1 1 3 1 3 1 1 3 1
+] debugIsEqual
+
+(AB) (dontdraw) rationalizedCodabar /sbs get  % Empty body allowed
+[
+    1 1 3 3 1 3 1 1 1 3 1 3 1 1 3 1
+] debugIsEqual
+
+(TN) (dontdraw altstartstop) rationalizedCodabar /sbs get  % Same as above
+[
+    1 1 3 3 1 3 1 1 1 3 1 3 1 1 3 1
+] debugIsEqual

--- a/tests/ps_tests/test.ps
+++ b/tests/ps_tests/test.ps
@@ -117,6 +117,7 @@
     (../../../tests/ps_tests/pdf417compact.ps)
     (../../../tests/ps_tests/posicode.ps)
     (../../../tests/ps_tests/qrcode.ps)
+    (../../../tests/ps_tests/rationalizedCodabar.ps)
     (../../../tests/ps_tests/rectangularmicroqrcode.ps)
     (../../../tests/ps_tests/royalmail.ps)
     (../../../tests/ps_tests/ultracode.ps)


### PR DESCRIPTION
For `rationalizedCodabar`, check length at least 2 (or 3 if `validatecheck` given) to avoid a PS fail in the `charvals` `getinterval` (#17).