### PR TITLE
sscc18: Move length check before BadAI check to avoid PS fail (#17)

### DIFF
--- a/src/sscc18.ps
+++ b/src/sscc18.ps
@@ -68,11 +68,11 @@ begin
     /hasspace text length barcode length ne def
 
     % Validate the input
-    barcode 0 4 getinterval (\(00\)) ne {
-        /bwipp.sscc18badAI (SSCC-18 must begin with (00) application identifier) //raiseerror exec
-    } if
     barcode length 21 ne barcode length 22 ne and {
         /bwipp.sscc18badLength (SSCC-18 must be 17 or 18 digits) //raiseerror exec
+    } if
+    barcode 0 4 getinterval (\(00\)) ne {
+        /bwipp.sscc18badAI (SSCC-18 must begin with (00) application identifier) //raiseerror exec
     } if
     barcode 4 barcode length 4 sub getinterval {
         dup 48 lt exch 57 gt or {

--- a/tests/ps_tests/sscc18.ps
+++ b/tests/ps_tests/sscc18.ps
@@ -1,0 +1,28 @@
+%!PS
+
+% vim: set ts=4 sw=4 et :
+
+/sscc18 dup /uk.co.terryburton.bwipp findresource cvx def
+
+/eq_tmpl {
+    exch { 0 (dontdraw) sscc18 /sbs get } dup 3 -1 roll 0 exch put
+    exch isEqual
+} def
+
+/er_tmpl {
+    exch { 0 (dontdraw) sscc18 /sbs get } dup 3 -1 roll 0 exch put
+    exch isError
+} def
+
+
+((00)095287654321012346)
+    [2 1 1 2 3 2 4 1 1 1 3 1 2 1 2 2 2 2 2 2 1 2 1 3 2 1 3 3 1 1 4 2 1 1 1 2 1 2 1 1 2 4 1 1 2 3 3 1 2 1 3 2 1 2 2 2 2 1 2 2 3 1 2 1 3 1 1 1 3 3 2 1 2 2 1 2 1 3 2 3 3 1 1 1 2]
+    eq_tmpl
+
+
+((00)095287654321012345)  /bwipp.sscc18badCheckDigit  er_tmpl
+()                        /bwipp.sscc18badLength      er_tmpl
+((00)0952876543210123456) /bwipp.sscc18badLength      er_tmpl
+((00)0952876543210123)    /bwipp.sscc18badLength      er_tmpl
+((00)0952876543210123A)   /bwipp.sscc18badCharacter   er_tmpl
+((01)095287654321012345)  /bwipp.sscc18badAI          er_tmpl

--- a/tests/ps_tests/test.ps
+++ b/tests/ps_tests/test.ps
@@ -119,6 +119,7 @@
     (../../../tests/ps_tests/qrcode.ps)
     (../../../tests/ps_tests/rectangularmicroqrcode.ps)
     (../../../tests/ps_tests/royalmail.ps)
+    (../../../tests/ps_tests/sscc18.ps)
     (../../../tests/ps_tests/ultracode.ps)
     (../../../tests/ps_tests/upca.ps)
     (../../../tests/ps_tests/upcacomposite.ps)


### PR DESCRIPTION
For `sscc18`, move length check before BadAI check to avoid PS fail on BadAI `getinterval` (#17)