### PR TITLE
qrcode: Avoid initial B0 seq when input starts 6+ digits then kanji

### DIFF
--- a/src/qrcode.ps
+++ b/src/qrcode.ps
@@ -539,6 +539,7 @@ begin
                     modeBKbeforeE KbeforeB {K exit} if  % Re-using modeB KbeforeE array
                     mode0forceKB  KbeforeE {K exit} if
                     numK 1 ge {B exit} if
+                    mode0NbeforeB NbeforeK {N exit} if
                     mode0NbeforeB NbeforeB {N exit} if
                     mode0forceKB  NbeforeB {B exit} if
                     modeANbeforeE NbeforeA {N exit} if  % Re-using modeA NbeforeE array

--- a/tests/ps_tests/qrcode.ps
+++ b/tests/ps_tests/qrcode.ps
@@ -121,6 +121,11 @@
     (^000^000^000^000^000^000K9K9K9K9K9K9K) (parse version=1 eclevel=L debugcws) qrcode
 } [64 112 0 0 0 0 0 4 178 6 26 147 82 106 77 73 169 53 32] debugIsEqual
 
+{
+    % N6 K1 with mode0NbeforeB NbeforeK -> N in mode -1, previously had 0-length B0 seq prefixed due to mode -1 -> B and then immediately -> N
+    (123456^138^197) (parse version=1 eclevel=H debugcws) qrcode
+} [16 24 123 114 32 4 232 160 236] debugIsEqual
+
 
 % Figures
 


### PR DESCRIPTION
Avoids initial zero-length byte sequence when input starts with 6+ digits followed by kanji by adding `mode0NbeforeB NbeforeK` -> N check in mode -1.

Previously would -> B in mode -1 then bounce immediately to -> N in mode B (due to `modeBNbeforeK NbeforeK` check).

Now 4+ digits will cause mode N to be used, same as `NbeforeB`, which seems reasonable and conservative I think given that deciding between mode N and mode B.

Alternatively could just check for `charslen` being zero when looping through the sequences and skip if so... more defensive in case there're other ways 0-length sequences could arise but somewhat hacky?

(Discovered this when adding a test case to Zint for the "invalid byte pairs in Kanji mode" fix [8fcbe7c]. Note the barcode still decodes ok, just unnecessary bloat.)
