### PR TITLE
code128: Avoid extraneous CodeC switch

### DIFF
--- a/src/code128.ps
+++ b/src/code128.ps
@@ -213,9 +213,9 @@ begin
         /msg msgtmp def
         /msglen msg length def
 
-        % Determine digit runlength and characters from given position
+        % Determine digit runlength from given position
         /numsscr {
-            /n 0 def /s 0 def
+            /s 0 def
             /p exch def {
                 p msglen ge {exit} if
                 msg p get
@@ -226,11 +226,10 @@ begin
                 } {
                     pop
                 } ifelse
-                /n n 1 add def
                 /s s 1 add def
                 /p p 1 add def
             } loop
-            n s
+            s
         } def
 
         % Encoding for each alphabet
@@ -281,7 +280,7 @@ begin
 
         % Select start character
         /j 0 def
-        msglen 0 gt {0 numsscr} {-1 -1} ifelse /nums exch def /nchars exch def
+        msglen 0 gt {0 numsscr} {-1} ifelse /nums exch def
         {  % common exit
             msglen 0 eq {
                 stb enca
@@ -312,7 +311,7 @@ begin
         /i 0 def {
             i msglen eq {exit} if
 
-            i numsscr /nums exch def /nchars exch def
+            i numsscr /nums exch def
 
             % Determine switches and shifts
             {  % common exit
@@ -325,9 +324,11 @@ begin
                     } {
                         msg i get cset (seta) eq {enca} {encb} ifelse
                         /i i 1 add def
-                        swc cset (seta) eq {enca} {encb} ifelse
-                        /cset (setc) def
-                        exit
+                        i numsscr 4 ge {
+                            swc cset (seta) eq {enca} {encb} ifelse
+                            /cset (setc) def
+                            exit
+                       } if
                     } ifelse
                 } if
                 cset (setb) eq msg i get anotb and {

--- a/tests/ps_tests/code128.ps
+++ b/tests/ps_tests/code128.ps
@@ -10,3 +10,7 @@
 {  % Allow for FNC4 immediately after CodeC sequence (cf https://github.com/woo-j/OkapiBarcode/commit/9ce6dccbab20d1190090585ddf91a7f549f4fac9)
     (^193^193^193^193^193^19399999999999999^193) (debugcws parse) code128
 } [104 100 100 33 33 33 33 33 33 100 100 99 99 99 99 99 99 99 99 100 100 33 3 106] debugIsEqual
+
+{  % Avoid extraneous CodeC switch (with immediate switch back to CodeA/B) by re-checking digit runlength >= 4 after enca/encb push
+    (12^FNC1345^FNC167^FNC18) (debugcws parse parsefnc) code128
+} [105 12 102 34 100 21 102 22 23 102 24 49 106] debugIsEqual

--- a/tests/ps_tests/gs1-128.ps
+++ b/tests/ps_tests/gs1-128.ps
@@ -15,3 +15,7 @@
 ((01)09501101530003)  % GS1 General Specifications Figure 5.1-3. GS1-128 barcode, same
     [2 1 1 2 3 2 4 1 1 1 3 1 2 2 2 1 2 2 2 2 1 2 1 3 2 3 1 1 3 1 2 3 1 2 1 2 2 2 2 1 2 2 2 1 3 1 3 1 2 1 2 2 2 2 1 2 1 2 2 3 1 2 2 1 1 4 2 3 3 1 1 1 2]
     eq_tmpl
+
+{  % Avoid extraneous CodeC switch (with immediate switch back to CodeA/B) by re-checking digit runlength >= 4 after enca/encb push
+    ((90)1(91)2(92)3) (debugcws) gs1-128
+} [105 102 90 100 17 102 25 17 18 102 25 18 19 79 106] debugIsEqual


### PR DESCRIPTION
Avoid extraneous CodeC switch (with immediate switch back to CodeA/B) by re-checking digit runlength >= 4 after enca/encb push

Also simplify `numsscr` to return only `nums` as `nchars` unused (cf codablockf and code16k which similarly could be simplified)
