### PR TITLE
code128: reduce extended latch cut-off from 5 to 4

### DIFF
--- a/src/code128.ps
+++ b/src/code128.ps
@@ -194,30 +194,36 @@ begin
         } for
 
         % FNC4 codeword insertion for extended ASCII
-        /ea false def /msgtmp [] def
+        /ea false def /msgtmp [] def /numEAtmp [] def
         0 1 msglen 1 sub {
             /i exch def
             /c msg i get def
+            /n numEA i get def
             ea c 128 lt xor not c 0 ge and {  % Other mode required
                 ea {numSA} {numEA} ifelse i get dup  % Runlength of other mode
-                i add msglen eq {3} {5} ifelse       % Does run terminate symbol
+                i add msglen eq {3} {4} ifelse       % Does run terminate symbol
                 lt {  % Shift
                     /msgtmp [ msgtmp aload pop fn4 ] def
+                    /numEAtmp [ numEAtmp aload pop 1 ] def
                 } {   % Latch
                     /msgtmp [ msgtmp aload pop fn4 fn4 ] def
+                    /numEAtmp [ numEAtmp aload pop 1 1 ] def
                     /ea ea not def
                 } ifelse
             } if
             /msgtmp [ msgtmp aload pop c 0 ge {c 127 and} {c} ifelse ] def
+            /numEAtmp [ numEAtmp aload pop n ] def
         } for
         /msg msgtmp def
         /msglen msg length def
+        /numEA numEAtmp def
 
         % Determine digit runlength from given position
         /numsscr {
             /s 0 def
             /p exch def {
                 p msglen ge {exit} if
+                numEA p get 0 gt {exit} if
                 msg p get
                 dup setc exch known not {pop exit} if
                 dup -1 le {

--- a/tests/ps_tests/code128.ps
+++ b/tests/ps_tests/code128.ps
@@ -11,6 +11,26 @@
     (^193^193^193^193^193^19399999999999999^193) (debugcws parse) code128
 } [104 100 100 33 33 33 33 33 33 100 100 99 99 99 99 99 99 99 99 100 100 33 3 106] debugIsEqual
 
+{  % Ignore extended ASCII in numsscr ("±" (^177) maps to "1" when masked to ASCII)
+    (^177^177^177^1771234AA) (debugcws parse) code128
+} [104 100 100 17 17 17 17 100 100 99 12 34 100 33 33 21 106] debugIsEqual
+
+{  % Minimize FNC4 insertion using non-terminal 4 char cut-off instead of 5
+    ( ^160^160^160^160 ^160^160^160^160 ) (debugcws parse) code128
+} [104 0 100 100 0 0 0 0 100 0 0 0 0 0 100 0 23 106] debugIsEqual
+
+{  % Now unlatches and re-latches with 4 middle spaces (same no. of codewords as if shifts instead)
+    ( ^160^160^160^160    ^160^160^160^160 ) (debugcws parse) code128
+} [104 0 100 100 0 0 0 0 100 100 0 0 0 0 100 100 0 0 0 0 100 0 97 106] debugIsEqual
+
+{  % TODO: could be 1 codeword smaller by shifting the 2 "A"s instead of unlatching and shifting final "^128"
+    (^128^128^128^128^128A0000A^128) (debugcws parse) code128
+} [103 101 101 64 64 64 64 64 101 101 33 99 0 0 101 33 101 64 73 106] debugIsEqual
+
 {  % Avoid extraneous CodeC switch (with immediate switch back to CodeA/B) by re-checking digit runlength >= 4 after enca/encb push
     (12^FNC1345^FNC167^FNC18) (debugcws parse parsefnc) code128
 } [105 12 102 34 100 21 102 22 23 102 24 49 106] debugIsEqual
+
+{  % Don't start in C if A or B would be more efficient
+    (123^FNC14567) (debugcws parse parsefnc) code128
+} [104 17 99 23 102 45 67 84 106] debugIsEqual


### PR DESCRIPTION
Latch/unlatch extended on 4 chars instead of 5 for better
encodation in certain cases (and no pessimizations found so far),
part addresses PR #272, props lyngklip

Also fix masked extended chars matching ASCII digits in `numsscr`
(skipped using re-synced `numEA` array)

This is the first of two alternative PRs, the second one being
an implementation of Alex Geller's divide & conquer algorithm as
used by ZXing (and Zint)