### PR TITLE
code128: Add minimal encodation algorithm (non-extended ASCII only)

### DIFF
--- a/src/code128.ps
+++ b/src/code128.ps
@@ -179,58 +179,161 @@ begin
             text i msg i get dup 0 lt { pop 32 } if put
         } for
 
-        % Standard and extended ASCII runlength at position
-        /numSA [ msglen {0} repeat 0 ] def
-        /numEA [ msglen {0} repeat 0 ] def
-        msglen 1 sub -1 0 {
-            /i exch def
-            msg i get 0 ge {
-                msg i get 128 ge {
-                    numEA i numEA i 1 add get 1 add put
-                } {
-                    numSA i numSA i 1 add get 1 add put
-                } ifelse
-            } if
-        } for
+        % Divide-And-Conquer with Memoization by Alex Geller, adapted from ZXing - see
+        % https://github.com/zxing/zxing/commit/94fb277607003c070ffd1413754a782f3f87cbcd
 
-        % FNC4 codeword insertion for extended ASCII
-        /ea false def /msgtmp [] def
+        /canc {
+            msg p get dup 48 ge exch 57 le and {
+                p 1 add msglen lt {
+                    msg p 1 add get dup 48 ge exch 57 le and
+                } {
+                    false
+                } ifelse
+            } {
+                setc msg p get known
+            } ifelse
+        } def
+
+        /canaorb {
+            {
+                msg p get -1 le { tryset 1 eq {seta} {setb} ifelse msg p get known exit } if
+                msg p get 31 le { tryset 1 eq exit } if
+                msg p get 95 le { true exit } if
+                msg p get 127 le { tryset 2 eq exit } if
+                msg p get 159 le { tryset 1 eq exit } if
+                msg p get 223 le { true exit } if
+                tryset 2 eq exit
+            } loop
+        } def
+
+        %                A (1)                 B (2)                 C (3)
+        /costs [ [ 0 ] [ msglen {0} repeat ] [ msglen {0} repeat ] [ msglen {0} repeat ] ] def
+        /modes [ [ 0 ] [ msglen {0} repeat ] [ msglen {0} repeat ] [ msglen {0} repeat ] ] def
+
+        /p 0 def /cs 0 def /mincost 0 def /minlatch 0 def /cost 0 def /latch 0 def /tryset 0 def  % Recursive state
+
+        /dmcost {  % Args charset cs and msg index p
+            p cs mincost minlatch cost latch tryset  % Save state on recursion
+            9 -2 roll  % Move args to front
+            /p exch def
+            /cs exch def
+            costs cs get p get 0 ne {  % Memoized?
+                costs cs get p get
+            } {
+                /mincost 999999 def
+                /minlatch 0 def
+                canc {  % Mode C
+                    /advance msg p get fn1 eq {1} {2} ifelse def
+                    /cost 1 def
+                    /latch 0 def  % Continue in current `cs`
+                    cs 3 ne { /cost cost 1 add def /latch 3 def } if
+                    p advance add msglen lt {
+                        /cost cost 3 p advance add dmcost add def
+                    } if
+                    cost mincost lt { /mincost cost def /minlatch latch def } if
+                } if
+                2 -1 1 {  % Mode B then A
+                    /tryset exch def
+                    canaorb {
+                        /cost 1 def
+                        /latch 0 def  % Continue in current `cs`
+                        cs tryset ne { /cost cost 1 add def /latch tryset def } if
+                        p 1 add msglen lt { /cost cost tryset p 1 add dmcost add def } if
+                        cost mincost lt { /mincost cost def /minlatch latch def } if
+                        cs tryset ne cs 1 eq cs 2 eq or and {
+                            /cost 2 def
+                            /latch cs 3 add def  % Shift A/B
+                            p 1 add msglen lt { /cost cost cs p 1 add dmcost add def } if
+                            cost mincost lt { /mincost cost def /minlatch latch def } if
+                        } if
+                    } if
+                } for
+                costs cs get p mincost put
+                modes cs get p minlatch put
+                mincost
+            } ifelse
+
+            8 1 roll  % Move saved state to front and restore
+            /tryset exch def /latch exch def /cost exch def /minlatch exch def /mincost exch def /cs exch def /p exch def
+        } def
+
+        msglen 0 gt { 0 0 dmcost pop } if
+
+        % ASCII modes: 1 A, 2 B, 3 C, 4 shift from B, 5 shift from A
+        /aset msglen array def
+        /cs 0 def
+        /i 0 def
+        {
+            i msglen ge {exit} if
+            /latch modes cs get i get def
+            latch 4 ge latch 5 le and {  % Shift A/B
+                /cs latch 3 sub def
+                aset i latch put
+            } {
+                latch 1 ge latch 3 le and { /cs latch def } if  % Else continue in current `cs`
+                aset i cs put
+                cs 3 eq msg i get 0 ge and { /i i 1 add def aset i cs put } if  % Guaranteed to be in range by algorithm
+            } ifelse
+            /i i 1 add def
+        } loop
+
+        % Extended ASCII modes: 0 not extended, 1 extended shift, 2 extended latch, 3 ASCII shift from extended
+        /eset [ msglen {0} repeat ] def
         0 1 msglen 1 sub {
             /i exch def
-            /c msg i get def
-            ea c 128 lt xor not c 0 ge and {  % Other mode required
-                ea {numSA} {numEA} ifelse i get dup  % Runlength of other mode
-                i add msglen eq {3} {5} ifelse       % Does run terminate symbol
-                lt {  % Shift
-                    /msgtmp [ msgtmp aload pop fn4 ] def
-                } {   % Latch
-                    /msgtmp [ msgtmp aload pop fn4 fn4 ] def
-                    /ea ea not def
-                } ifelse
-            } if
-            /msgtmp [ msgtmp aload pop c 0 ge {c 127 and} {c} ifelse ] def
+            msg i get 128 ge { eset i 1 put } if
         } for
-        /msg msgtmp def
-        /msglen msg length def
 
-        % Determine digit runlength from given position
-        /numsscr {
-            /s 0 def
-            /p exch def {
-                p msglen ge {exit} if
-                msg p get
-                dup setc exch known not {pop exit} if
-                dup -1 le {
-                    % FNC1 in odd position of run like two digits
-                    fn1 eq s 2 mod 0 eq and {/s s 1 add def} {exit} ifelse
-                } {
-                    pop
-                } ifelse
-                /s s 1 add def
-                /p p 1 add def
-            } loop
-            s
-        } def
+        % Decide when to latch to extended - ISO/IEC 15417:2007 Annex E note 3
+        /j 0 def /k 0 def
+        0 1 msglen 1 sub {
+            /i exch def
+            eset i get 1 eq {
+                /j j 1 add def
+                j 4 ge {
+                    eset i 2 put
+                    k 0 eq {
+                        eset i 1 sub 2 put eset i 2 sub 2 put eset i 3 sub 2 put
+                        /k i def
+                    } if
+                } if
+            } {
+                /j 0 def /k 0 def
+            } ifelse
+        } for
+        j 3 ge k 0 eq and {
+            eset msglen 1 sub 2 put eset msglen 2 sub 2 put eset msglen 3 sub 2 put
+        } if
+
+        % Decide if it is worth reverting to ASCII encodation for a few characters as described in 4.3.4.2 (d)
+        1 1 msglen 1 sub {
+            /i exch def
+            eset i 1 sub get 2 eq eset i get 0 eq and {
+                % Detected a change from extended to ASCII - count ASCII
+                /c aset i get 3 eq {1} {0} ifelse def  % Count C so can subtract when deciding below
+                /j 1 def
+                1 1 msglen i sub {
+                    /j exch def
+                    i j add msglen ge {exit} if
+                    eset i j add get 0 ne {exit} if
+                    aset i j add get 3 eq { /c c 1 add def } if
+                } for
+                % Count how many extended beyond
+                /k i j add msglen lt {1} {0} ifelse def
+                k 1 msglen i j add sub {
+                    /k exch def
+                    i j add k add msglen ge {exit} if
+                    eset i j add k add get 0 eq {exit} if
+                } for
+                j c sub 3 lt j c sub 5 lt k 2 gt and or {
+                    % Change to shifting rather than latching back
+                    0 1 j 1 sub {
+                        /k exch def
+                        eset i k add 3 put
+                    } for
+                } if
+            } if
+        } for
 
         % Encoding for each alphabet
         /enca {
@@ -251,148 +354,94 @@ begin
             /j j 1 add def
         } def
 
-        % Character exclusively in either alphabet A or B
-        /anotb {dup seta exch known exch setb exch known not and} def
-        /bnota {dup setb exch known exch seta exch known not and} def
-
-        % Pre-compute relative position of next anotb and next bnota characters
-        /nextanotb [ msg length {0} repeat 9999 ] def
-        /nextbnota [ msg length {0} repeat 9999 ] def
-        msg length 1 sub -1 0 {
-            /i exch def
-            msg i get anotb {
-                nextanotb i 0 put
-            } {
-                nextanotb i nextanotb i 1 add get 1 add put
-            } ifelse
-            msg i get bnota {
-                nextbnota i 0 put
-            } {
-                nextbnota i nextbnota i 1 add get 1 add put
-            } ifelse
-        } for
-
-        % Does a-only come before b-only after given position and vice versa
-        /abeforeb {dup nextanotb exch get exch nextbnota exch get lt} def
-        /bbeforea {dup nextbnota exch get exch nextanotb exch get lt} def
-
         /cws barcode length 2 mul 3 add array def
 
         % Select start character
         /j 0 def
-        msglen 0 gt {0 numsscr} {-1} ifelse /nums exch def
         {  % common exit
             msglen 0 eq {
                 stb enca
-                /cset (setb) def
+                /cset 2 def
                 exit
             } if
-            msglen 2 eq nums 2 eq and {
-                stc enca
-                /cset (setc) def
-                exit
-            } if
-            nums 4 ge {
-                stc enca
-                /cset (setc) def
-                exit
-            } if
-            0 abeforeb {
+            aset 0 get 1 eq {  % StartA
                 sta enca
-                /cset (seta) def
+                /cset 1 def
                 exit
             } if
-            stb enca
-            /cset (setb) def
+            aset 0 get 3 eq {  % StartC
+                stc enca
+                /cset 3 def
+                exit
+            } if
+            stb enca  % StartB
+            /cset 2 def
             exit
         } loop
 
         % Main encoding loop
+        /estate false def  % Extended latch state
         /i 0 def {
             i msglen eq {exit} if
-
-            i numsscr /nums exch def
-
+            /aseti aset i get def
+            /eseti eset i get def
             % Determine switches and shifts
-            {  % common exit
-                cset (seta) eq cset (setb) eq or nums 4 ge and
-                msg i get fn1 ne and {
-                    nums 2 mod 0 eq {
-                        swc cset (seta) eq {enca} {encb} ifelse
-                        /cset (setc) def
-                        exit
-                    } {
-                        msg i get cset (seta) eq {enca} {encb} ifelse
-                        /i i 1 add def
-                        i numsscr 4 ge {
-                            swc cset (seta) eq {enca} {encb} ifelse
-                            /cset (setc) def
-                            exit
-                       } if
-                    } ifelse
-                } if
-                cset (setb) eq msg i get anotb and {
-                    i msglen 1 sub lt {
-                        i 1 add bbeforea {
-                            sft encb
-                            msg i get enca
-                            /i i 1 add def
-                            exit
-                        } if
-                    } if
+            aseti cset ne {
+                aseti 1 eq {
                     swa encb
-                    /cset (seta) def
-                    exit
+                    /cset 1 def
                 } if
-                cset (seta) eq msg i get bnota and {
-                    i msglen 1 sub lt {
-                        i 1 add abeforeb {
-                            sft enca
-                            msg i get encb
-                            /i i 1 add def
-                            exit
-                        } if
-                    } if
+                aseti 2 eq {
                     swb enca
-                    /cset (setb) def
-                    exit
+                    /cset 2 def
                 } if
-                cset (setc) eq nums 2 lt and msg i get -1 gt msg i get fn4 eq or and {
-                    i abeforeb {
-                        swa encc
-                        /cset (seta) def
-                        exit
+                aseti 3 eq {
+                    swc enca
+                    /cset 3 def
+                } if
+            } if
+
+            eseti 2 eq estate not and eseti 0 eq estate and or {
+                cset 1 eq {
+                    fn4 enca fn4 enca
+                    /estate estate not def
+                } if
+                cset 2 eq {
+                    fn4 encb fn4 encb
+                    /estate estate not def
+                } if
+            } {
+                eseti 1 eq estate not and eseti 3 eq estate and or {
+                    cset 1 eq {
+                        fn4 enca
                     } if
-                    swb encc
-                    /cset (setb) def
-                    exit
+                    cset 2 eq {
+                        fn4 encb
+                    } if
                 } if
+            } ifelse
 
-                % No switches or latches so encode
-                cset (seta) eq {
-                    msg i get enca
+            aseti 4 eq aseti 5 eq or {
+                sft enca
+            } if
+
+            aseti 1 eq aseti 5 eq or {  % A
+                msg i get dup 0 ge {127 and} if enca
+                /i i 1 add def
+            } if
+            aseti 2 eq aseti 4 eq or {  % B
+                msg i get dup 0 ge {127 and} if encb
+                /i i 1 add def
+            } if
+            aseti 3 eq {  % C
+                msg i get -1 le {
+                    msg i get encc
                     /i i 1 add def
-                    exit
-                } if
-                cset (setb) eq {
-                    msg i get encb
-                    /i i 1 add def
-                    exit
-                } if
-                cset (setc) eq {
-                    msg i get -1 le {
-                        msg i get encc
-                        /i i 1 add def
-                    } {
-                        msg i 2 getinterval encc
-                        /i i 2 add def
-                    } ifelse
-                    exit
-                } if
-
-                exit
-            } loop
-
+                } {
+                    msg i 2 getinterval encc
+                    /i i 2 add def
+                } ifelse
+            } if
         } loop
         /cws cws 0 j getinterval def
     } if  % auto encoding

--- a/tests/ps_tests/code128.ps
+++ b/tests/ps_tests/code128.ps
@@ -9,8 +9,48 @@
 
 {  % Allow for FNC4 immediately after CodeC sequence (cf https://github.com/woo-j/OkapiBarcode/commit/9ce6dccbab20d1190090585ddf91a7f549f4fac9)
     (^193^193^193^193^193^19399999999999999^193) (debugcws parse) code128
-} [104 100 100 33 33 33 33 33 33 100 100 99 99 99 99 99 99 99 99 100 100 33 3 106] debugIsEqual
+} [104 100 100 33 33 33 33 33 33 99 99 99 99 99 99 99 99 100 33 91 106] debugIsEqual
+
+{  % Ignore extended ASCII in numsscr ("±" (^177) maps to "1" when masked to ASCII) (obsolete)
+    (^177^177^177^1771234AA) (debugcws parse) code128
+} [104 100 100 17 17 17 17 99 12 34 100 100 33 100 33 89 106] debugIsEqual
+
+{  % Minimize FNC4 insertion using non-terminal 4 char cut-off instead of 5 (PR #272, lyngklip)
+    ( ^160^160^160^160 ^160^160^160^160 ) (debugcws parse) code128
+} [104 0 100 100 0 0 0 0 100 0 0 0 0 0 100 0 23 106] debugIsEqual
+
+{  % Still uses shifts with 4 middle spaces (same codeword count as if unlatched)
+    ( ^160^160^160^160    ^160^160^160^160 ) (debugcws parse) code128
+} [104 0 100 100 0 0 0 0 100 0 100 0 100 0 100 0 0 0 0 0 100 0 0 106] debugIsEqual
+
+{  % Unlatches with 5 middle spaces
+    ( ^160^160^160^160     ^160^160^160^160 ) (debugcws parse) code128
+} [104 0 100 100 0 0 0 0 100 100 0 0 0 0 0 100 100 0 0 0 0 100 0 88 106] debugIsEqual
+
+{  % Doesn't unlatch with 6 middle ASCII (as ignores mode C chars) and shifts final extended
+    (^128^128^128^128^128A0000A^128) (debugcws parse) code128
+} [103 101 101 64 64 64 64 64 101 33 99 0 0 101 101 33 64 4 106] debugIsEqual
+
+{  % OkapiBarcode "code128/fnc1-mode-c-fnc1-in-middle.png"
+    (^FNC112345^FNC11234^FNC112345) (debugcws parsefnc) code128
+} [104 102 17 99 23 45 102 12 34 102 12 34 100 21 72 106] debugIsEqual
 
 {  % Avoid extraneous CodeC switch (with immediate switch back to CodeA/B) by re-checking digit runlength >= 4 after enca/encb push
-    (12^FNC1345^FNC167^FNC18) (debugcws parse parsefnc) code128
+    (12^FNC1345^FNC167^FNC18) (debugcws parsefnc) code128
 } [105 12 102 34 100 21 102 22 23 102 24 49 106] debugIsEqual
+
+{  % Don't switch to C when 2 digits are followed by FNC1 followed by a non-C character (PR #272, lyngklip)
+    ( 12^FNC1 ) (debugcws parsefnc) code128
+} [104 0 17 18 102 0 85 106] debugIsEqual
+
+{  % Do switch to C when an even number of digits are followed by FNC1 and then by an odd number of digits (PR #272, lyngklip)
+    ( 1234^FNC1567) (debugcws parsefnc) code128
+} [104 0 99 12 34 102 56 100 23 41 106] debugIsEqual
+
+{  % Don't start in C if A or B would be more efficient (PR #272, lyngklip)
+    (123^FNC14567) (debugcws parsefnc) code128
+} [104 17 99 23 102 45 67 84 106] debugIsEqual
+
+{  % Mix of code sets, shifts and latches
+    (^031^031_^127^159^031^159^159^159^15912345``^255^000^127^255^224^224^159`) (debugcws parse) code128
+} [103 95 95 63 98 95 101 95 95 101 101 95 95 95 95 99 12 34 100 100 100 21 64 64 100 95 98 64 95 100 100 95 64 64 98 95 100 64 51 106] debugIsEqual

--- a/tests/ps_tests/gs1-128.ps
+++ b/tests/ps_tests/gs1-128.ps
@@ -18,4 +18,8 @@
 
 {  % Avoid extraneous CodeC switch (with immediate switch back to CodeA/B) by re-checking digit runlength >= 4 after enca/encb push
     ((90)1(91)2(92)3) (debugcws) gs1-128
-} [105 102 90 100 17 102 25 17 18 102 25 18 19 79 106] debugIsEqual
+} [105 102 90 100 17 102 25 99 12 102 92 100 19 14 106] debugIsEqual
+
+{  % Further encodation improvement (3 codewords less) with divide & conquer algorithm
+    ((90)123(91)1234(92)123) (debugcws) gs1-128
+} [104 102 25 99 1 23 102 91 12 34 102 92 12 100 19 91 106] debugIsEqual


### PR DESCRIPTION
Adapted from ZXing (props Alex Geller) - maybe 80% slower depending
on data & stack heavy but does improve some outcomes when FNC1s
present (GS1 or manual) although not much else it appears (the
previous algorithm was pretty good)

Prompted by tests added from PR #272, props lyngklip

This is the second of the alternative PRs (PR #275). You choose!