### PR TITLE
parseinput: allow for double caret at end

### DIFF
--- a/src/parseinput.ps.src
+++ b/src/parseinput.ps.src
@@ -138,15 +138,19 @@ begin
 
                 % parsefnc
                 /j j 1 sub def
-                dup length 3 lt {
+                dup length 1 lt {
                     pop
-                    /bwipp.truncatedFNC (Function character truncated) //raiseerror exec
+                    /bwipp.truncatedCaret (Caret character truncated) //raiseerror exec
                 } if
                 dup 0 get 94 eq {  % "^^" -> "^"
                     msg j 94 put
                     /j j 1 add def
                     dup length 1 sub 1 exch getinterval
                     exit
+                } if
+                dup length 3 lt {
+                    pop
+                    /bwipp.truncatedFNC (Function character truncated) //raiseerror exec
                 } if
                 dup 0 3 getinterval (ECI) eq eci and {  % "^ECInnnnnn" -> -1nnnnnn
                     dup length 9 lt {

--- a/tests/ps_tests/parseinput.ps.test
+++ b/tests/ps_tests/parseinput.ps.test
@@ -158,9 +158,21 @@
     (AB^^FNC1C) << /parse false /parsefnc true (FNC1) -1 >> parseinput
 } [ 65 66 94 70 78 67 49 67 ]  isEqual
 
-{  % Truncated
+{  % Escaped "^^" -> "^" at end
+    (AB^^) << /parse false /parsefnc true (FNC1) -1 >> parseinput
+} [ 65 66 94 ]  isEqual
+
+{  % Truncated FNC
     (ABC^FNC) << /parse false /parsefnc true (FNC1) -1 >> parseinput
 } /bwipp.truncatedFNC isError
+
+{  % Truncated FNC
+    (ABC^F) << /parse false /parsefnc true (FNC1) -1 >> parseinput
+} /bwipp.truncatedFNC isError
+
+{  % Truncated caret
+    (ABC^) << /parse false /parsefnc true (FNC1) -1 >> parseinput
+} /bwipp.truncatedCaret isError
 
 {  % No such FNC
     (A^FNC2BC) << /parse false /parsefnc true (FNC1) -1 >> parseinput


### PR DESCRIPTION
and error if truncated before erroring for truncated FNC