### PR TITLE
codablockf: ignore 2nd byte of FNC4 when counting digits in `numsscr`

### DIFF
--- a/src/codablockf.ps.src
+++ b/src/codablockf.ps.src
@@ -1,7 +1,7 @@
 % Barcode Writer in Pure PostScript
 % https://bwipp.terryburton.co.uk
 %
-% Copyright (c) 2004-2024 Terry Burton
+% Copyright (c) 2004-2025 Terry Burton
 %
 % $Id$
 %
@@ -170,6 +170,9 @@ begin
         /n 0 def /s 0 def
         /p exch def {
             p msglen ge {exit} if
+            p 0 ne {  % Check not 2nd byte of FNC4
+                msg p 1 sub get fn4 eq {exit} if
+            } if
             msg p get
             dup setc exch known not {pop exit} if
             fn1 eq {

--- a/tests/ps_tests/codablockf.ps.test
+++ b/tests/ps_tests/codablockf.ps.test
@@ -1,7 +1,7 @@
 % Barcode Writer in Pure PostScript
 % https://bwipp.terryburton.co.uk
 %
-% Copyright (c) 2004-2024 Terry Burton
+% Copyright (c) 2004-2025 Terry Burton
 
 % AIM Europe ISS-X-24 - Uniform Symbology Specification - Codablock F (1995)
 
@@ -31,6 +31,9 @@
     (@g\(^194^194^194^194^1945555^194^194^194^194^194^194^194^194) (debugcws parse columns=18) codablockf
 } [103 100 64 32 71 8 100 34 100 34 100 34 100 34 100 34 99 55 55 100 99 75 104 103 100 11 100 34 100 34 100 34 100 34 100 34 100 34 100 34 100 34 52 35 30 104] debugIsEqual
 
+{  % Ignore 2nd byte of FNC4 when counting digits in `numsscr`
+    (^238^159V^200^182767) (debugcws parse columns=8) codablockf
+} [103 100 64 100 78 100 101 95 54 101 40 26 104 103 100 11 100 22 23 22 23 99 60 63 99 104] debugIsEqual
 
 % Example
 


### PR DESCRIPTION
(Found via "backend/tests/test_bwipp" - same bug in zint.)