### PR TITLE
dotcode: Ensure cols >= 5 when large rows, little data

### DIFF
--- a/src/dotcode.ps.src
+++ b/src/dotcode.ps.src
@@ -862,6 +862,7 @@ begin
     } {
         columns -1 eq {  % Fixed height
             /columns minarea rows add 1 sub rows idiv dup rows add 2 mod 0 eq {1 add} if def
+            columns 5 lt { /columns 5 rows -1 ne { rows 2 mod add } if def } if
         } if
         rows -1 eq {     % Fixed width
             /rows minarea columns add 1 sub columns idiv dup columns add 2 mod 0 eq {1 add} if def

--- a/tests/ps_tests/dotcode.ps.test
+++ b/tests/ps_tests/dotcode.ps.test
@@ -50,6 +50,10 @@
     (0) (columns=116 debugcws) dotcode  % Ensure rows >= 5 when large cols, little data
 } [102 16 106 106 106 106 106 106 106 106 106 106 106 106 106 106 106 106 106] debugIsEqual
 
+{
+    (0) (rows=29 debugcws) dotcode  % Ensure cols >= 5 when large rows, little data
+} [102 16 106 106] debugIsEqual
+
 
 % Figures
 


### PR DESCRIPTION
Should have done this also in the last one.