### PR TITLE
dotcode: Don't check if not last char at end of `encBIN`

### DIFF
--- a/src/dotcode.ps.src
+++ b/src/dotcode.ps.src
@@ -789,25 +789,22 @@ begin
                 } if
             } if
             [ finaliseBIN ] addtocws
-            i msglen 1 sub ne {  % Not last character
-                msg i get //dotcode.fn3 eq i segstart ne and {  % FNC3
-                    [ BINvals //dotcode.tms get ] addtocws
-                    /i i 1 add def
-                    /mode C def
-                    /inmac 0 def
-                    /segstart i def
-                    /segend i UntilEndSeg i get add def
-                    exit
-                } if
-                AheadA i get AheadB i get gt {
-                    [ BINvals //dotcode.tma get ] addtocws
-                    /mode A def
-                } {
-                    [ BINvals //dotcode.tmb get ] addtocws
-                    /mode B def
-                } ifelse
+            msg i get //dotcode.fn3 eq i segstart ne and {  % FNC3
+                [ BINvals //dotcode.tms get ] addtocws
+                /i i 1 add def
+                /mode C def
+                /inmac 0 def
+                /segstart i def
+                /segend i UntilEndSeg i get add def
                 exit
             } if
+            AheadA i get AheadB i get gt {
+                [ BINvals //dotcode.tma get ] addtocws
+                /mode A def
+            } {
+                [ BINvals //dotcode.tmb get ] addtocws
+                /mode B def
+            } ifelse
             exit
         } repeat
     } def

--- a/tests/ps_tests/dotcode.ps.test
+++ b/tests/ps_tests/dotcode.ps.test
@@ -54,6 +54,10 @@
     (0) (rows=29 debugcws) dotcode  % Ensure cols >= 5 when large rows, little data
 } [102 16 106 106] debugIsEqual
 
+{
+    (^128^128a) (parse debugcws) dotcode  % Binary latch ending in single non-binary
+} [112 3 14 11 110 65] debugIsEqual
+
 
 % Figures
 


### PR DESCRIPTION
Otherwise binary input ending with a non-binary will cause the
`encfuncs` loop not to terminate as neither `i` nor `mode` changed