### PR TITLE
datamatrix: unlatch from Base 256 if FNC1

### DIFF
--- a/src/datamatrix.ps.src
+++ b/src/datamatrix.ps.src
@@ -603,11 +603,12 @@ begin
             1 {  % common exit
                 isECI i get {//datamatrix.A exit} if  % ECI only in ASCII
                 i c40headerlength lt {//datamatrix.C exit} if  % C40 only for c40headerlength characters
+                /isfnc1 msg i get //datamatrix.fnc1 eq def
                 /k 0 def {  % loop
                     i k add msglen eq {
                         [/ac /cc /tc /xc /ec /bc] {dup load ceiling def} forall
                         true [   cc tc xc ec bc] {ac exch le and} forall {//datamatrix.A exit} if
-                        true [ac cc tc xc ec   ] {bc exch lt and} forall {//datamatrix.B exit} if
+                        true [ac cc tc xc ec   ] {bc exch lt and} forall {isfnc1 {//datamatrix.A} {//datamatrix.B} ifelse exit} if
                         true [ac cc tc xc    bc] {ec exch lt and} forall {//datamatrix.E exit} if
                         true [ac cc    xc ec bc] {tc exch lt and} forall {//datamatrix.T exit} if
                         true [ac cc tc    ec bc] {xc exch lt and} forall {//datamatrix.X exit} if
@@ -622,8 +623,8 @@ begin
                     /bc bc isFN {4 add} {1 add} ifelse def
                     k 4 ge {
                         true [   cc tc xc ec bc] {ac 1 add exch le and} forall {//datamatrix.A exit} if
-                        bc 1 add ac le {//datamatrix.B exit} if
-                        true [   cc tc xc ec   ] {bc 1 add exch lt and} forall {//datamatrix.B exit} if
+                        bc 1 add ac le {isfnc1 {//datamatrix.A} {//datamatrix.B} ifelse exit} if
+                        true [   cc tc xc ec   ] {bc 1 add exch lt and} forall {isfnc1 {//datamatrix.A} {//datamatrix.B} ifelse exit} if
                         true [ac cc tc xc    bc] {ec 1 add exch lt and} forall {//datamatrix.E exit} if
                         true [ac cc    xc ec bc] {tc 1 add exch lt and} forall {//datamatrix.T exit} if
                         true [ac cc tc    ec bc] {xc 1 add exch lt and} forall {//datamatrix.X exit} if

--- a/tests/ps_tests/datamatrix.ps.test
+++ b/tests/ps_tests/datamatrix.ps.test
@@ -710,6 +710,16 @@
     44 65 216 110  % randomised length+data bytes
 ] debugIsEqual
 
+% Unlatch from base256 if FNC1: "ロ^FNC1ワ" (UTF-8 Katakana)
+{ (^227^131^173^FNC1^227^131^175) (debugcws parse parsefnc) datamatrix } [
+    231             % lB256
+    47 164 218 153  % randomised length+data bytes
+    232             % FNC1
+    231             % lB256
+    176 38 91 29    % randomised length+data bytes
+    129             % PAD
+] debugIsEqual
+
 
 %
 % EDIFACT mode


### PR DESCRIPTION
In lookup, on Base 256 exit, return ASCII instead if FNC1.