### PR TITLE
ISBN/ISMN/ISSN: migrate label text to the extratext (text2) framework

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+XXXX-XX-XX
+
+* ISBN/ISMN/ISSN label text was migrated to the extratext (text2) framework, enabling support for all text placement options including extratextgaps, extratextxalign, extratextcolor, extratextdirection and extratextfont. Existing encoder-specific options (e.g. isbntextfont) remain supported as defaults that can be overridden by the corresponding extratext option.
+
+
 2026-04-21
 
 * An addondescent option was added to EAN/UPC symbols to control the descent of add-on bars independently of guarddescent. It defaults to the value of guarddescent so the add-on matches the primary unless overridden.

--- a/contrib/development/compare_isbn_text.sh
+++ b/contrib/development/compare_isbn_text.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+set -e
+
+# ── Configuration ────────────────────────────────────────────────────────────
+OUTDIR="/tmp/drive_isbn_compare"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MAKE_IMAGE="$SCRIPT_DIR/make_image.sh"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+FMT=pnm
+
+export PATH="/opt/homebrew/bin:$PATH"
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+gen() {
+    local outdir="$1" name="$2" encoder="$3" data="$4" opts="$5"
+    "$MAKE_IMAGE" --scale=3 "$FMT" "$encoder" "$data" "$opts" > "$outdir/${name}.${FMT}"
+    echo "  $name"
+}
+
+generate_images() {
+    local outdir="$1"
+
+    [ -f "$REPO_ROOT/build/monolithic/barcode.ps" ] || { echo "Run 'make' first"; exit 1; }
+
+    mkdir -p "$outdir"
+    echo "Generating images in $outdir/ ..."
+
+    # ISBN-13 variants
+    gen "$outdir" isbn13-base        isbn '978-1-56581-231-4'         'includetext'
+    gen "$outdir" isbn13-guard       isbn '978-1-56581-231-4'         'includetext guardwhitespace'
+    gen "$outdir" isbn13-addon       isbn '978-1-56581-231-4 90000'   'includetext'
+    gen "$outdir" isbn13-font        isbn '978-1-56581-231-4'         'includetext isbntextfont=/Helvetica'
+    gen "$outdir" isbn13-size        isbn '978-1-56581-231-4'         'includetext isbntextsize=12'
+    gen "$outdir" isbn13-xoff        isbn '978-1-56581-231-4'         'includetext isbntextxoffset=5'
+    gen "$outdir" isbn13-yoff        isbn '978-1-56581-231-4'         'includetext isbntextyoffset=80'
+    gen "$outdir" isbn13-etfont      isbn '978-1-56581-231-4'         'includetext extratextfont=/Helvetica'
+    gen "$outdir" isbn13-gaps        isbn '978-1-56581-231-4'         'includetext extratextgaps=2'
+    gen "$outdir" isbn13-center      isbn '978-1-56581-231-4'         'includetext extratextxalign=center'
+    gen "$outdir" isbn13-color       isbn '978-1-56581-231-4'         'includetext extratextcolor=FF0000'
+    gen "$outdir" isbn13-direction   isbn '978-1-56581-231-4'         'includetext extratextdirection=backward'
+    gen "$outdir" isbn13-ybelow      isbn '978-1-56581-231-4'         'includetext extratextyalign=below'
+    gen "$outdir" isbn13-precedence  isbn '978-1-56581-231-4'         'includetext isbntextfont=/Helvetica extratextfont=/Times-Roman'
+    gen "$outdir" isbn13-customtext  isbn '978-1-56581-231-4'         'includetext extratext=CustomText'
+    gen "$outdir" isbn13-propspec    isbn '978-1-56581-231-4'         'includetext propspec'
+    gen "$outdir" isbn13-strictspec  isbn '978-1-56581-231-4'         'includetext strictspec xdim=0.330'
+    gen "$outdir" isbn13-notext      isbn '978-1-56581-231-4'         ''
+
+    # ISBN-10 variants
+    gen "$outdir" isbn10-base        isbn '1-56581-231-X'             'includetext'
+    gen "$outdir" isbn10-legacy      isbn '1-56581-231-X'             'includetext legacy'
+
+    # ISMN-13 variants
+    gen "$outdir" ismn13-base        ismn '979-0-2605-3211-3'         'includetext'
+    gen "$outdir" ismn13-addon       ismn '979-0-2605-3211-3 12345'   'includetext'
+    gen "$outdir" ismn13-font        ismn '979-0-2605-3211-3'         'includetext ismntextfont=/Helvetica'
+    gen "$outdir" ismn13-gaps        ismn '979-0-2605-3211-3'         'includetext extratextgaps=2'
+    gen "$outdir" ismn13-propspec    ismn '979-0-2605-3211-3'         'includetext propspec'
+    gen "$outdir" ismn13-notext      ismn '979-0-2605-3211-3'         ''
+
+    # ISMN-10 variants
+    gen "$outdir" ismn10-base        ismn 'M-2605-3211'               'includetext'
+    gen "$outdir" ismn10-legacy      ismn 'M-2605-3211'               'includetext legacy'
+
+    # ISSN variants
+    gen "$outdir" issn-base          issn '0311-175X 00 17'           'includetext'
+    gen "$outdir" issn-addon         issn '0311-175X 00 12345'        'includetext'
+    gen "$outdir" issn-font          issn '0311-175X 00 17'           'includetext issntextfont=/Helvetica'
+    gen "$outdir" issn-gaps          issn '0311-175X 00 17'           'includetext extratextgaps=2'
+    gen "$outdir" issn-propspec      issn '0311-175X 00 17'           'includetext propspec'
+    gen "$outdir" issn-notext        issn '0311-175X'                 ''
+
+    echo "Done. $(ls "$outdir"/*."$FMT" | wc -l) images in $outdir/"
+}
+
+diff_images() {
+    local before="$1" after="$2" diffdir="$3"
+
+    mkdir -p "$diffdir"
+
+    for f in "$before"/*.pnm; do
+        local b out metric status
+        b=$(basename "$f")
+        out="$diffdir/${b%.pnm}.png"
+
+        status=0
+        metric=$(magick compare \
+            -highlight-color red \
+            -lowlight-color white \
+            -metric AE \
+            "$before/$b" \
+            "$after/$b" \
+            "$out" 2>&1 >/dev/null) || status=$?
+
+        if [ $status -eq 0 ]; then
+            rm -f "$out"
+            echo "ok: $b"
+        elif [ $status -eq 1 ]; then
+            echo "DIFF: $b - $metric pixels differ"
+        else
+            rm -f "$out"
+            echo "ERROR: $b"
+            echo "$metric"
+        fi
+    done
+}
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+cd "$REPO_ROOT"
+
+rm -rf "$OUTDIR"
+mkdir -p "$OUTDIR"/{before,after,diff}
+
+echo "==> Building on master branch..."
+git switch master
+make -j "$(sysctl -n hw.ncpu)"
+generate_images "$OUTDIR/before"
+
+echo "==> Building on feature branch..."
+git switch isbn-gaptext
+make -j "$(sysctl -n hw.ncpu)"
+generate_images "$OUTDIR/after"
+
+echo "==> Comparing images..."
+diff_images "$OUTDIR/before" "$OUTDIR/after" "$OUTDIR/diff"

--- a/src/isbn.ps.src
+++ b/src/isbn.ps.src
@@ -303,24 +303,44 @@ begin
     barcode options //ean13 exec /args exch def
 
     %
-    % Add the ISBN text
+    % Populate ISBN text as text2.
+    % Compatibility rule:
+    %   set text2* defaults only when neither text2* nor extratext*
+    %   values were explicitly provided.
     %
     includetext {
-        isbntextxoffset null eq {
-            /isbntextxoffset isbn length 9 eq {-1.0} {-12.0} ifelse def
+        /textUnset    options (text2) known not        options (extratext) known not        and def
+        /fontUnset    options (text2font) known not    options (extratextfont) known not    and def
+        /sizeUnset    options (text2size) known not    options (extratextsize) known not    and def
+        /xalignUnset  options (text2xalign) known not  options (extratextxalign) known not  and def
+        /xoffsetUnset options (text2xoffset) known not options (extratextxoffset) known not and def
+        /yalignUnset  options (text2yalign) known not  options (extratextyalign) known not  and def
+        /yoffsetUnset options (text2yoffset) known not options (extratextyoffset) known not and def
+
+        /xoffsetExplicit isbntextxoffset null ne def   % snapped before we touch the global
+
+        isbntextyoffset null eq {                      % update global unconditionally
+            /isbntextyoffset 2.0 def
         } if
-        isbntextyoffset null eq {
-            /isbntextyoffset args (bhs) get 2 get 72 mul 3 add def
-        } if
-        args (txt) known {
-            /txt args (txt) get def
-            /newtxt txt length 1 add array def
-            newtxt 0 txt putinterval
-            newtxt newtxt length 1 sub [isbntxt isbntextxoffset isbntextyoffset isbntextfont isbntextsize] put
-            args (txt) newtxt put
+
+        textUnset  { options (text2)     isbntxt      put } if
+        fontUnset  { options (text2font) isbntextfont put } if
+        sizeUnset  { options (text2size) isbntextsize put } if
+
+        xalignUnset {
+            options (text2xalign) (left) put
+            xoffsetExplicit not {                      % update global only here, matching original
+                /isbntextxoffset isbn length 9 eq { -1.0 } { -12.0 } ifelse def
+            } if
+            xoffsetUnset { options (text2xoffset) isbntextxoffset put } if
         } {
-            args (txt) [ [isbntxt isbntextxoffset isbntextyoffset isbntextfont isbntextsize] ] put
+            xoffsetExplicit xoffsetUnset and {         % propagate only if caller supplied a value
+                options (text2xoffset) isbntextxoffset put
+            } if
         } ifelse
+
+        yalignUnset  { options (text2yalign)  (above)          put } if
+        yoffsetUnset { options (text2yoffset) isbntextyoffset  put } if
     } if
 
     args (opt) options put

--- a/src/ismn.ps.src
+++ b/src/ismn.ps.src
@@ -282,24 +282,44 @@ begin
     barcode options //ean13 exec /args exch def
 
     %
-    % Add the ISMN text
+    % Populate ISMN text as text2.
+    % Compatibility rule:
+    %   set text2* defaults only when neither text2* nor extratext*
+    %   values were explicitly provided.
     %
     includetext {
-        ismntextxoffset null eq {
-            /ismntextxoffset ismntxt length 18 eq {-1.0} {-12.0} ifelse def
-        } if
+        /textUnset    options (text2) known not        options (extratext) known not        and def
+        /fontUnset    options (text2font) known not    options (extratextfont) known not    and def
+        /sizeUnset    options (text2size) known not    options (extratextsize) known not    and def
+        /xalignUnset  options (text2xalign) known not  options (extratextxalign) known not  and def
+        /xoffsetUnset options (text2xoffset) known not options (extratextxoffset) known not and def
+        /yalignUnset  options (text2yalign) known not  options (extratextyalign) known not  and def
+        /yoffsetUnset options (text2yoffset) known not options (extratextyoffset) known not and def
+
+        /xoffsetExplicit ismntextxoffset null ne def
+
         ismntextyoffset null eq {
-            /ismntextyoffset args (bhs) get 2 get 72 mul 3 add def
+            /ismntextyoffset 2.0 def
         } if
-        args (txt) known {
-            /txt args (txt) get def
-            /newtxt txt length 1 add array def
-            newtxt 0 txt putinterval
-            newtxt newtxt length 1 sub [ismntxt ismntextxoffset ismntextyoffset ismntextfont ismntextsize] put
-            args (txt) newtxt put
+
+        textUnset  { options (text2)     ismntxt      put } if
+        fontUnset  { options (text2font) ismntextfont put } if
+        sizeUnset  { options (text2size) ismntextsize put } if
+
+        xalignUnset {
+            options (text2xalign) (left) put
+            xoffsetExplicit not {
+                /ismntextxoffset ismntxt length 18 eq { -1.0 } { -12.0 } ifelse def
+            } if
+            xoffsetUnset { options (text2xoffset) ismntextxoffset put } if
         } {
-            args (txt) [ [ismntxt ismntextxoffset ismntextyoffset ismntextfont ismntextsize] ] put
+            xoffsetExplicit xoffsetUnset and {
+                options (text2xoffset) ismntextxoffset put
+            } if
         } ifelse
+
+        yalignUnset  { options (text2yalign)  (above)           put } if
+        yoffsetUnset { options (text2yoffset) ismntextyoffset   put } if
     } if
 
     args (opt) options put

--- a/src/issn.ps.src
+++ b/src/issn.ps.src
@@ -229,20 +229,44 @@ begin
     barcode options //ean13 exec /args exch def
 
     %
-    % Add the ISSN text
+    % Populate ISSN text as text2.
+    % Compatibility rule:
+    %   set text2* defaults only when neither text2* nor extratext*
+    %   values were explicitly provided.
     %
     includetext {
-        issntextxoffset null eq {/issntextxoffset 10.0 def} if
-        issntextyoffset null eq {/issntextyoffset args (bhs) get 2 get 72 mul 3 add def} if
-        args (txt) known {
-            /txt args (txt) get def
-            /newtxt txt length 1 add array def
-            newtxt 0 txt putinterval
-            newtxt newtxt length 1 sub [issntxt issntextxoffset issntextyoffset issntextfont issntextsize] put
-            args (txt) newtxt put
+        /textUnset    options (text2) known not        options (extratext) known not        and def
+        /fontUnset    options (text2font) known not    options (extratextfont) known not    and def
+        /sizeUnset    options (text2size) known not    options (extratextsize) known not    and def
+        /xalignUnset  options (text2xalign) known not  options (extratextxalign) known not  and def
+        /xoffsetUnset options (text2xoffset) known not options (extratextxoffset) known not and def
+        /yalignUnset  options (text2yalign) known not  options (extratextyalign) known not  and def
+        /yoffsetUnset options (text2yoffset) known not options (extratextyoffset) known not and def
+
+        /xoffsetExplicit issntextxoffset null ne def
+
+        issntextyoffset null eq {
+            /issntextyoffset 2.0 def
+        } if
+
+        textUnset  { options (text2)     issntxt      put } if
+        fontUnset  { options (text2font) issntextfont put } if
+        sizeUnset  { options (text2size) issntextsize put } if
+
+        xalignUnset {
+            options (text2xalign) (left) put
+            xoffsetExplicit not {
+                /issntextxoffset 10.0 def
+            } if
+            xoffsetUnset { options (text2xoffset) issntextxoffset put } if
         } {
-            args (txt) [ [issntxt issntextxoffset issntextyoffset issntextfont issntextsize] ] put
+            xoffsetExplicit xoffsetUnset and {
+                options (text2xoffset) issntextxoffset put
+            } if
         } ifelse
+
+        yalignUnset  { options (text2yalign)  (above)           put } if
+        yoffsetUnset { options (text2yoffset) issntextyoffset   put } if
     } if
 
     args (opt) options put

--- a/tests/ps_tests/isbn.ps.test
+++ b/tests/ps_tests/isbn.ps.test
@@ -48,3 +48,40 @@
 
 % AST consumption: SST profile resolves through wrapper
 { (978-1-56581-231-4) (dontdraw strictspec ast=gs1.sst2) isbn dup /strictspec get exch /xdim get 2 array astore } [true 0.660] isEqual
+
+%
+% Extratext (text2) migration tests
+%
+
+% ISBN label populates text2 in options when includetext is set
+{ (978-1-56581-231-4) (dontdraw includetext) isbn /opt get (text2) get }
+(ISBN 978-1-56581-231-4) isEqual
+
+% txt array has 13 entries (EAN-13 digits only, no ISBN label tuple)
+{ (978-1-56581-231-4) (dontdraw includetext) isbn /txt get length 1 array astore }
+[13] isEqual
+
+% text2 is not set when includetext is off
+{ (978-1-56581-231-4) (dontdraw) isbn /opt get (text2) known not 1 array astore }
+[true] isEqual
+
+% Backward compat: isbntextfont flows to text2font
+{ (978-1-56581-231-4) (dontdraw includetext isbntextfont=/Helvetica) isbn /opt get (text2font) get 127 string cvs }
+(/Helvetica) isEqual
+
+% New option extratextfont overrides isbntextfont: text2font is not in opt
+{ (978-1-56581-231-4) (dontdraw includetext isbntextfont=/Helvetica extratextfont=/Times-Roman) isbn /opt get (text2font) known not 1 array astore }
+[true] isEqual
+
+% User-supplied extratext overrides encoder label: text2 is not in opt
+{ (978-1-56581-231-4) (dontdraw includetext extratext=Custom) isbn /opt get (text2) known not 1 array astore }
+[true] isEqual
+
+% Smoke test: renders with extratextgaps
+{ 0 0 moveto (978-1-56581-231-4) (includetext extratextgaps=2) isbn true } true isEqual
+
+% Smoke test: renders with extratextcolor
+{ 0 0 moveto (978-1-56581-231-4) (includetext extratextcolor=FF0000) isbn true } true isEqual
+
+% Smoke test: renders with extratextxalign=center
+{ 0 0 moveto (978-1-56581-231-4) (includetext extratextxalign=center) isbn true } true isEqual

--- a/tests/ps_tests/ismn.ps.test
+++ b/tests/ps_tests/ismn.ps.test
@@ -38,3 +38,22 @@
 
 % propspec smoke test
 { 0 0 moveto (979-0-2605-3211-3) (propspec) ismn true } true isEqual
+
+%
+% Extratext (text2) migration tests
+%
+
+% ISMN label populates text2 in options when includetext is set
+{ (979-0-2605-3211-3) (dontdraw includetext) ismn /opt get (text2) get }
+(ISMN 979-0-2605-3211-3) isEqual
+
+% text2 is not set when includetext is off
+{ (979-0-2605-3211-3) (dontdraw) ismn /opt get (text2) known not 1 array astore }
+[true] isEqual
+
+% Backward compat: ismntextfont flows to text2font
+{ (979-0-2605-3211-3) (dontdraw includetext ismntextfont=/Helvetica) ismn /opt get (text2font) get 127 string cvs }
+(/Helvetica) isEqual
+
+% Smoke test: renders with extratextgaps
+{ 0 0 moveto (979-0-2605-3211-3) (includetext extratextgaps=2) ismn true } true isEqual

--- a/tests/ps_tests/issn.ps.test
+++ b/tests/ps_tests/issn.ps.test
@@ -31,3 +31,22 @@
 
 % propspec smoke test
 { 0 0 moveto (0311-175X 00 17) (propspec) issn true } true isEqual
+
+%
+% Extratext (text2) migration tests
+%
+
+% ISSN label populates text2 in options when includetext is set
+{ (0311-175X 00 17) (dontdraw includetext) issn /opt get (text2) get }
+(ISSN 0311-175X) isEqual
+
+% text2 is not set when includetext is off
+{ (0311-175X) (dontdraw) issn /opt get (text2) known not 1 array astore }
+[true] isEqual
+
+% Backward compat: issntextfont flows to text2font
+{ (0311-175X 00 17) (dontdraw includetext issntextfont=/Helvetica) issn /opt get (text2font) get 127 string cvs }
+(/Helvetica) isEqual
+
+% Smoke test: renders with extratextgaps
+{ 0 0 moveto (0311-175X 00 17) (includetext extratextgaps=2) issn true } true isEqual


### PR DESCRIPTION
# Overview

This arose because there was no way to set the textgap option on the ISBN text above the barcode. We now send that ISBN label through the extratext/text2 framework to enable textgap and any other options within that framework.

## Details

- Replace legacy txt tuple append with text2 option population in isbn.ps.src, ismn.ps.src, and issn.ps.src, enabling all text group features (gaps, alignment, color, direction) for the label
- Encoder-specific defaults (isbntextfont, isbntextsize, etc.) are propagated as text2 defaults; explicit extratext* options take precedence via alias-aware known-not guards
- Default x-offset is only applied when using the default left alignment; non-left alignments (e.g. center) are not polluted by the default x-offset
- Add PS test coverage for text2 population, includetext gating, backward-compat font propagation, precedence, and render smoke tests
- Add contrib/development/compare_isbn_text.sh for PNM regression images across all encoder/option combinations. Specific to this feature branch - we may want to remove it before merging.
- Add CHANGES entry documenting the new extratext support

Fixes #308 