### PR TITLE
telepennumeric: implement DLE switch to trailing ASCII

### DIFF
--- a/src/telepen.ps.src
+++ b/src/telepen.ps.src
@@ -136,10 +136,6 @@ begin
     /barlen barcode length def
     options (parse) undef
 
-    numeric barlen 2 mod 0 ne and {
-        /bwipp.telepenNumericOddLength (Telepen Numeric must have an even length) //raiseerror exec
-    } if
-
     %
     % Apply AST spec overrides and resolve physical specification
     %
@@ -156,11 +152,14 @@ begin
     /l enc length def
 
     /checksum 0 def
-    /i 0 def /j 0 def
+    /i 0 def
     { % loop
         i barlen eq {exit} if
         numeric {
-            barcode i get 16 gt {  % 00-99 or 0X-9X
+            barcode i get dup 16 gt exch 127 lt and {  % 00-99 or 0X-9X
+                barlen i sub 2 lt {  % Check for pair
+                    /bwipp.telepenNumericNotDigitPair (Telepen Numeric must be in digit pairs) //raiseerror exec
+                } if
                 /np barcode i 2 getinterval def
                 np 0 get dup 48 lt exch 57 gt or
                 np 1 get dup 48 lt 1 index 57 gt or exch 88 eq not and
@@ -177,8 +176,11 @@ begin
                 /indx exch def
                 % numeric pair displayed via barcode
                 /i i 2 add def
-            } {  % Ordinal values 0-16
+            } {  % Ordinal values 0-16 and 127 (DEL)
                 /indx barcode i get def
+                indx 127 gt {
+                    /bwipp.telepenInvalidNumericControlCharacter (Telepen Numeric control characters must have ordinal values 0 to 16 or 127) //raiseerror exec
+                } if
                 /i i 1 add def
             } ifelse
         } {  % ASCII mode
@@ -192,7 +194,6 @@ begin
         /enc //telepen.encs indx get def
         sbs l enc putinterval          % Put encoded digit into sbs
         /l l enc length add def
-        /j j 1 add def
     } loop
 
     %

--- a/src/telepen.ps.src
+++ b/src/telepen.ps.src
@@ -137,12 +137,30 @@ begin
     options (parse) undef
 
     %
+    % Check numeric for DLE (ASCII 16) indicating switch to trailing ASCII
+    %
+    /trailasclen 0 def
+    numeric {
+        barcode <10> search {
+            /barcode exch def
+            /trailasc barlen barcode length sub string def
+            trailasc exch 0 exch putinterval  % DLE
+            trailasc exch 1 exch putinterval
+            /barlen barcode length def
+            barlen 0 eq {
+                /bwipp.telepenNumericDLEFirstCharacter (DLE cannot be first character in Telepen Numeric) //raiseerror exec
+            } if
+            /trailasclen trailasc length def
+        } { pop } ifelse
+    } if
+
+    %
     % Apply AST spec overrides and resolve physical specification
     %
     /telepen ast /apply_ast //render exec not { //raiseerror exec } if
     /resolve_strictspec //render exec
 
-    /sbs barlen 16 mul 48 add string def
+    /sbs barlen trailasclen add 16 mul 48 add string def
 
     %
     % Put the start character ASCII 95
@@ -196,6 +214,17 @@ begin
         /l l enc length add def
     } loop
 
+    0 1 trailasclen 1 sub {
+        trailasc exch get /indx exch def
+        indx 127 gt {
+            /bwipp.telepenInvalidAlphaCharacter (Telepen Alpha characters must have ordinal values 0 to 127) //raiseerror exec
+        } if
+        /checksum checksum indx add def
+        /enc //telepen.encs indx get def
+        sbs l enc putinterval
+        /l l enc length add def
+    } for
+
     %
     % Put the checksum character
     %
@@ -217,11 +246,16 @@ begin
     /sbs sbs 0 l getinterval def
 
     % Build display text: replace non-printable chars with spaces
-    /text barcode length string def
+    /text barcode length trailasclen add string def
     0 1 barcode length 1 sub {
         /i exch def
         /c barcode i get def
         text i c 32 ge c 126 le and { c } { 32 } ifelse put
+    } for
+    1 1 trailasclen 1 sub {  % Skip initial DLE
+        /i exch def
+        /c trailasc i get def
+        text i 1 sub barcode length add c 32 ge c 126 le and { c } { 32 } ifelse put
     } for
 
     /sbs [sbs {48 sub} forall] def

--- a/tests/ps_tests/telepen.ps.test
+++ b/tests/ps_tests/telepen.ps.test
@@ -3,7 +3,7 @@
 %
 % vim: set sw=4 sts=4 et:
 %
-% Copyright (c) 2004-2025 Terry Burton
+% Copyright (c) 2004-2026 Terry Burton
 %
 
 /telepen dup /uk.co.terryburton.bwipp findresource cvx def
@@ -16,9 +16,14 @@
 % Error tests
 %
 
-{ (123) (numeric dontdraw) telepen } /bwipp.telepenNumericOddLength isError
+{ (123) (numeric dontdraw) telepen } /bwipp.telepenNumericNotDigitPair isError
 { (X123) (numeric dontdraw) telepen } /bwipp.telepenInvalidNumericCharacter isError
 { (ABC\200) (dontdraw) telepen } /bwipp.telepenInvalidAlphaCharacter isError
+{ (123^016) (numeric parse dontdraw) telepen } /bwipp.telepenInvalidNumericCharacter isError
+{ (123^200) (numeric parse dontdraw) telepen } /bwipp.telepenInvalidNumericCharacter isError
+{ (12^0153) (numeric parse dontdraw) telepen } /bwipp.telepenNumericNotDigitPair isError
+{ (12^1273) (numeric parse dontdraw) telepen } /bwipp.telepenNumericNotDigitPair isError
+{ (12^20034) (numeric parse dontdraw) telepen } /bwipp.telepenInvalidNumericControlCharacter isError
 
 { 501 string (dontdraw) telepen } /bwipp.telepeninputTooLong isError
 

--- a/tests/ps_tests/telepen.ps.test
+++ b/tests/ps_tests/telepen.ps.test
@@ -19,11 +19,14 @@
 { (123) (numeric dontdraw) telepen } /bwipp.telepenNumericNotDigitPair isError
 { (X123) (numeric dontdraw) telepen } /bwipp.telepenInvalidNumericCharacter isError
 { (ABC\200) (dontdraw) telepen } /bwipp.telepenInvalidAlphaCharacter isError
-{ (123^016) (numeric parse dontdraw) telepen } /bwipp.telepenInvalidNumericCharacter isError
+{ (123^016) (numeric parse dontdraw) telepen } /bwipp.telepenNumericNotDigitPair isError  % DLE now indicates trailing ASCII
+{ (123^015) (numeric parse dontdraw) telepen } /bwipp.telepenInvalidNumericCharacter isError
 { (123^200) (numeric parse dontdraw) telepen } /bwipp.telepenInvalidNumericCharacter isError
+{ (^016A) (numeric parse dontdraw) telepen } /bwipp.telepenNumericDLEFirstCharacter isError
 { (12^0153) (numeric parse dontdraw) telepen } /bwipp.telepenNumericNotDigitPair isError
 { (12^1273) (numeric parse dontdraw) telepen } /bwipp.telepenNumericNotDigitPair isError
 { (12^20034) (numeric parse dontdraw) telepen } /bwipp.telepenInvalidNumericControlCharacter isError
+{ (12^016^200) (numeric parse dontdraw) telepen } /bwipp.telepenInvalidAlphaCharacter isError
 
 { 501 string (dontdraw) telepen } /bwipp.telepeninputTooLong isError
 

--- a/tests/ps_tests/telepennumeric.ps.test
+++ b/tests/ps_tests/telepennumeric.ps.test
@@ -11,6 +11,9 @@
 { (01234567) (dontdraw) telepennumeric /sbs get
 } [ 1 1 1 1 1 1 1 1 1 1 3 3 3 1 1 1 1 1 1 1 3 1 1 1 3 3 1 3 1 3 1 1 3 1 3 3 3 3 1 3 1 1 1 1 1 3 1 1 1 1 3 3 1 1 3 1 3 1 3 3 1 1 1 1 1 1 1 1 1 1 ] debugIsEqual
 
+{ (12^0163) (parse dontdraw) telepennumeric /sbs get  % DLE indicating trailing ASCII
+} [ 1 1 1 1 1 1 1 1 1 1 3 3 1 1 1 1 1 1 3 1 1 1 3 1 3 1 3 1 1 1 3 1 1 1 1 1 1 1 3 1 1 1 1 1 3 1 1 1 3 3 1 1 3 1 1 1 3 3 1 1 1 1 1 1 1 1 1 1 ] debugIsEqual
+
 { (12^01534) (parse dontdraw) telepennumeric /sbs get  % May be odd length if contains control chars
 } [ 1 1 1 1 1 1 1 1 1 1 3 3 1 1 1 1 1 1 3 1 1 1 3 1 1 1 1 1 1 1 1 1 3 1 3 1 1 1 1 3 1 1 1 1 1 3 1 1 3 1 1 1 1 1 3 1 3 1 3 3 1 1 1 1 1 1 1 1 1 1 ] debugIsEqual
 

--- a/tests/ps_tests/telepennumeric.ps.test
+++ b/tests/ps_tests/telepennumeric.ps.test
@@ -3,10 +3,16 @@
 %
 % vim: set sw=4 sts=4 et:
 %
-% Copyright (c) 2004-2025 Terry Burton
+% Copyright (c) 2004-2026 Terry Burton
 %
 
 /telepennumeric dup /uk.co.terryburton.bwipp findresource cvx def
 
 { (01234567) (dontdraw) telepennumeric /sbs get
 } [ 1 1 1 1 1 1 1 1 1 1 3 3 3 1 1 1 1 1 1 1 3 1 1 1 3 3 1 3 1 3 1 1 3 1 3 3 3 3 1 3 1 1 1 1 1 3 1 1 1 1 3 3 1 1 3 1 3 1 3 3 1 1 1 1 1 1 1 1 1 1 ] debugIsEqual
+
+{ (12^01534) (parse dontdraw) telepennumeric /sbs get  % May be odd length if contains control chars
+} [ 1 1 1 1 1 1 1 1 1 1 3 3 1 1 1 1 1 1 3 1 1 1 3 1 1 1 1 1 1 1 1 1 3 1 3 1 1 1 1 3 1 1 1 1 1 3 1 1 3 1 1 1 1 1 3 1 3 1 3 3 1 1 1 1 1 1 1 1 1 1 ] debugIsEqual
+
+{ (12^12734) (parse dontdraw) telepennumeric /sbs get  % DEL control char
+} [ 1 1 1 1 1 1 1 1 1 1 3 3 1 1 1 1 1 1 3 1 1 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 3 1 1 1 1 1 3 1 1 1 1 1 1 1 3 1 3 3 1 3 3 1 1 1 1 1 1 1 1 1 1 ] debugIsEqual


### PR DESCRIPTION
Also:
- check for digit pairs instead of even length as input may be odd if it contains control chars.
- allow for DEL and check for extended ASCII.
- remove j remnant.